### PR TITLE
ci: remove CI tests from push to dev branch

### DIFF
--- a/.github/workflows/ci-sdk-python.yaml
+++ b/.github/workflows/ci-sdk-python.yaml
@@ -1,11 +1,11 @@
 # CI for Python SDK
-# Runs tests on PRs to main and pushes to main/dev branches
+# Runs tests on PRs to main and pushes to main branch
 
 name: Python SDK CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - 'sdk/python/**'
       - 'libs/soorma-common/**'


### PR DESCRIPTION
- CI now only runs on PRs to main and pushes to main
- Removed dev branch from push triggers
- Reduces unnecessary CI runs on development branch