### PR TITLE
feat: add zero-friction startup experience

### DIFF
--- a/examples/research-advisor/README.md
+++ b/examples/research-advisor/README.md
@@ -67,7 +67,7 @@ Future versions will add a **Tracker Service** for:
 
 1. **Start Soorma Platform** (Registry + Event Bus):
    ```bash
-   soorma dev
+   soorma dev --infra-only
    ```
 
 2. **Install dependencies**:
@@ -75,9 +75,9 @@ Future versions will add a **Tracker Service** for:
    pip install -r requirements.txt
    ```
 
-3. **Configure LLM** (optional - uses mocks without keys):
+3. **Configure LLM** (required):
    
-   The example supports multiple LLM providers via LiteLLM. Set any one of these API keys:
+   **You MUST have at least one API key** for the agents to function. The example supports multiple LLM providers via LiteLLM. Set any one of these:
    
    ```bash
    # OpenAI (default)
@@ -103,9 +103,21 @@ Future versions will add a **Tracker Service** for:
    
    The agents automatically detect which key is available and use the appropriate model. See `llm_utils.py` for model mappings.
 
-## Running the Example
+## 🚀 Running the Example
 
-Start each agent in a separate terminal:
+**Option A: The Easy Way (One Command)**
+
+Run the magic command to start all agents with one script:
+
+```bash
+bash start.sh
+```
+
+This starts all agents in the background and launches the interactive client. Press `Ctrl+C` to stop everything.
+
+**Option B: The Manual Way (Debug Mode)**
+
+If you want to see logs for each agent separately, open 5 terminals:
 
 ```bash
 # Terminal 1: Researcher

--- a/examples/research-advisor/requirements.txt
+++ b/examples/research-advisor/requirements.txt
@@ -1,3 +1,8 @@
+# Soorma Platform (ensure this is installed or install from local SDK)
+# pip install -e ../../sdk/python
+soorma-core>=0.4.0
+
+# LLM and utilities
 litellm>=1.0.0
 openai>=1.0.0
 pydantic>=2.0.0

--- a/examples/research-advisor/start.sh
+++ b/examples/research-advisor/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Kill all background jobs on exit
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+echo "🚀 Starting Research Advisor Swarm..."
+echo "Press Ctrl+C to stop all agents."
+
+# 1. Start Agents in background
+python researcher.py &
+PID1=$!
+echo " - Researcher started ($PID1)"
+
+python advisor.py &
+PID2=$!
+echo " - Advisor started ($PID2)"
+
+python validator.py &
+PID3=$!
+echo " - Validator started ($PID3)"
+
+python planner.py &
+PID4=$!
+echo " - Planner started ($PID4)"
+
+# Wait for agents to register
+sleep 3
+
+# 2. Run the Client (Interactive)
+echo "✅ Swarm ready. Starting Client..."
+python client.py


### PR DESCRIPTION
- Create start.sh script for one-command startup
- Eliminate 5-terminal friction (passes '5-Minute Rule')
- Update README with 'Magic Command' approach
- Add Option A (easy) and Option B (debug) running modes
- Clarify API key requirement (at least one required)
- Fix platform startup command to use --infra-only flag
- Add soorma-core to requirements.txt

Developer experience improvement: bash start.sh now starts entire swarm