### PR TITLE
chore(release): mark 0.5.0 as released (2025-12-23)\n\nUpdate CHANGEL…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Soorma Core project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2025-12-23
 
 ### Added
 - **Memory Service**: Complete implementation of persistent memory layer for autonomous agents

--- a/libs/soorma-common/CHANGELOG.md
+++ b/libs/soorma-common/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2025-12-23
 
 ### Added
 - **Memory Service DTOs**: Added comprehensive data models for Memory Service

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2025-12-23
 
 ### Added
 - **Memory Service SDK**: Complete MemoryClient implementation with CoALA framework support

--- a/services/event-service/CHANGELOG.md
+++ b/services/event-service/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2025-12-23
 
 ### Changed
 - Bumped version to 0.5.0 to align with unified platform release

--- a/services/memory/CHANGELOG.md
+++ b/services/memory/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2025-12-23
 
 ### Added
 - Initial release of Memory Service for Soorma platform

--- a/services/registry/CHANGELOG.md
+++ b/services/registry/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2025-12-23
 
 ### Changed
 - **Database**: Now uses PostgreSQL instead of SQLite in Docker Compose dev environment


### PR DESCRIPTION
…OGs to include release date for v0.5.0