### PR TITLE
docs: integrate examples refactoring into overall plan + SDK conveniences

### DIFF
--- a/EXAMPLES_REFACTOR_PLAN.md
+++ b/EXAMPLES_REFACTOR_PLAN.md
@@ -335,18 +335,18 @@ class EventDecision(BaseModel):
 - [x] Updated `docs/EVENT_PATTERNS.md` with topics section
 - [x] Updated all example READMEs to reflect correct topics and patterns
 
-### Phase 2: SDK Primitives (Week 1 - parallelize with Phase 1)
-> **Rationale:** Build SDK helpers first so examples can use them cleanly. Avoids "write it hard way then refactor" double work.
-
-- [ ] Implement `PlannerDecision` and `PlanAction` types in `soorma/ai/decisions.py`
-  - Include `trace_id` and `plan_id` fields for future State Tracker correlation
-- [ ] Implement `ChoreographyPlanner` class with Registry validation
-  - Add placeholder hook: `async def _register_plan(self, goal, context): pass`
-  - Add placeholder hook: `async def _report_decision(self, decision, context): pass`
-  - These no-ops will be wired to State Tracker later without breaking API
-- [ ] Implement `WorkflowState` helper in `soorma/workflow.py`
-- [ ] Add `format_for_llm_selection()` to EventToolkit
-- [ ] Update SDK CHANGELOG
+### Phase 2: SDK Primitives ✅ INTEGRATED
+> **Status:** SDK conveniences integrated into overall Soorma Core refactoring plan.  
+> **See:** [docs/refactoring/README.md](docs/refactoring/README.md) Stages 2-5
+>
+> The following SDK primitives are now part of the main refactoring:
+> - RF-SDK-014: WorkflowState helper (Stage 2)
+> - RF-SDK-015: PlannerDecision types (Stage 4)
+> - RF-SDK-016: ChoreographyPlanner class (Stage 4)
+> - RF-SDK-017: EventSelector utility (Stage 5)
+> - RF-SDK-018: EventToolkit.format_for_llm_selection() (Stage 5)
+>
+> **Examples refactoring will resume with Phase 3 after SDK implementation completes.**
 
 ### Phase 3: Memory Examples (Week 2)
 > **Depends on:** Phase 2 (`WorkflowState` helper)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@
   <br />
 </div>
 
+---
+
+> **📋 Refactoring in Progress**  
+> Soorma Core is undergoing a pre-launch refactoring to solidify architecture and SDK design.  
+> See [docs/refactoring/README.md](docs/refactoring/README.md) for details and status.  
+> Current focus: Stage 1 (Foundation - Event System) ✅ Complete
+
+---
+
 ## 🛡️ Mission
 
 Soorma is an agentic infrastructure platform based on the **DisCo (Distributed Cognition)** architecture. It solves the fragmentation in the AI agent ecosystem by providing a standardized **Control Plane** (Gateway, Registry, State, Pub/Sub) that allows distinct cognitive entities to discover each other and collaborate.


### PR DESCRIPTION
Major documentation updates:

## Refactoring Plan Integration
- Integrated examples refactoring Phase 2 (SDK Primitives) into overall plan
- Added RF-SDK-014 (WorkflowState helper) to Stage 2
- Added RF-SDK-015 (PlannerDecision types) to Stage 4
- Added RF-SDK-016 (ChoreographyPlanner class) to Stage 4
- Added RF-SDK-017 (EventSelector utility) to Stage 5
- Added RF-SDK-018 (EventToolkit LLM helpers) to Stage 5

## SDK Design Improvements
- Added comprehensive unit test plans for all new SDK conveniences
- Fixed concurrency issues in WorkflowState (removed in-memory cache)
- Added PlannerDecision.model_json_schema() for LLM prompt generation
- Added EventDecision.model_json_schema() for LLM prompt generation
- Updated ChoreographyPlanner to use schema-driven prompts
- Updated EventSelector to auto-append schema instructions (separation of concerns)
- Fixed event creation examples to use publish_envelope() pattern

## Documentation Structure
- Added refactoring status banner to root README
- Added Quick Reference section for new SDK conveniences
- Added Post-Refactoring section linking to examples development
- Updated EXAMPLES_REFACTOR_PLAN.md to reference integrated SDK work
- Added concurrency warnings and future enhancement sections

## Detailed Updates
- sdk/02-MEMORY-SDK.md: WorkflowState with fresh reads, concurrency docs
- sdk/06-PLANNER-MODEL.md: PlannerDecision types + ChoreographyPlanner class
- sdk/07-DISCOVERY.md: EventSelector utility + EventToolkit helpers
- All new tasks include comprehensive test plans (TDD)

Changes support build-in-public transparency and provide clear implementation roadmap.