### PR TITLE
fix: Change soorma-common dependency from local path to PyPI package

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -23,7 +23,7 @@ pydantic = "^2.0.0"
 typer = ">=0.13.0"  # 0.12.x had packaging issues with typer-slim split
 rich = ">=10.11.0"
 httpx = ">=0.26.0"  # For EventClient SSE streaming
-soorma-common = {path = "../../libs/soorma-common", develop = true}
+soorma-common = ">=0.7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"


### PR DESCRIPTION
- Remove local path dependency {path = "../../libs/soorma-common", develop = true}
- Use published PyPI version: soorma-common >= "0.7.0"
- Fixes PyPI upload error: Can't have direct dependency on file path