### PR TITLE
feat: propagate user_id through event envelope in examples

### DIFF
--- a/examples/05-memory-semantic/answer_agent.py
+++ b/examples/05-memory-semantic/answer_agent.py
@@ -91,6 +91,7 @@ async def _send_response(event: EventEnvelope, context: PlatformContext, payload
         event_type=QUESTION_ANSWERED_EVENT.event_name,
         data=payload.model_dump(),
         correlation_id=event.correlation_id,
+        user_id=event.user_id,  # Propagate user_id
     )
 
 
@@ -116,9 +117,9 @@ async def answer_question(event: EventEnvelope, context: PlatformContext):
     """
     data = event.data or {}
     question = data.get("question", "")
-    user_id = data.get("user_id", "00000000-0000-0000-0000-000000000001")
+    user_id = event.user_id  # User ID from event envelope
     
-    print(f"\n❓ Question: {question}")
+    print(f"\n❓ Question (user: {user_id}): {question}")
     
     # Step 1: Retrieve relevant knowledge from semantic memory
     print("🔍 Searching semantic memory...")

--- a/examples/05-memory-semantic/client.py
+++ b/examples/05-memory-semantic/client.py
@@ -14,13 +14,23 @@ Usage:
     # Single request mode
     python client.py "Python was created by Guido van Rossum"
     python client.py "Who created Python?"
+    
+    # Specify user ID (default: 00000000-0000-0000-0000-000000000001)
+    USER_ID=00000000-0000-0000-0000-000000000002 python client.py "Tell me about Python"
 """
 
 import asyncio
+import os
 import sys
 from uuid import uuid4
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
+
+
+# User ID can be set via environment variable (simulates authentication)
+# Note: Memory service currently expects UUID format
+DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000001"
+USER_ID = os.getenv("USER_ID", DEFAULT_USER_ID)
 
 
 async def send_request(request: str):
@@ -60,12 +70,15 @@ async def send_request(request: str):
     # Generate correlation ID
     correlation_id = str(uuid4())
     
-    # Publish user request event
+    print(f"   User: {USER_ID}")
+    
+    # Publish user request event with user_id in envelope
     await client.publish(
         event_type="user.request",
         topic=EventTopic.ACTION_REQUESTS,
         data={"request": request},
         correlation_id=correlation_id,
+        user_id=USER_ID,  # User ID propagates through event chain
     )
     
     print(f"   Request sent (correlation_id: {correlation_id})")

--- a/examples/05-memory-semantic/events.py
+++ b/examples/05-memory-semantic/events.py
@@ -15,7 +15,6 @@ from soorma_common import EventDefinition, EventTopic
 class UserRequestPayload(BaseModel):
     """User's natural language request."""
     request: str = Field(..., description="User's request in natural language")
-    user_id: str = Field(default="00000000-0000-0000-0000-000000000001", description="User ID for memory isolation")
 
 
 USER_REQUEST_EVENT = EventDefinition(
@@ -34,7 +33,6 @@ class StoreKnowledgePayload(BaseModel):
     """Request to store knowledge in semantic memory."""
     content: str = Field(..., description="Knowledge content to store")
     metadata: dict = Field(default_factory=dict, description="Optional metadata (source, category, etc.)")
-    user_id: str = Field(default="00000000-0000-0000-0000-000000000001", description="User ID for memory isolation")
 
 
 STORE_KNOWLEDGE_EVENT = EventDefinition(
@@ -48,7 +46,6 @@ STORE_KNOWLEDGE_EVENT = EventDefinition(
 class AnswerQuestionPayload(BaseModel):
     """Request to answer a question using stored knowledge."""
     question: str = Field(..., description="Question to answer")
-    user_id: str = Field(default="00000000-0000-0000-0000-000000000001", description="User ID for memory isolation")
 
 
 ANSWER_QUESTION_EVENT = EventDefinition(

--- a/examples/05-memory-semantic/knowledge_store.py
+++ b/examples/05-memory-semantic/knowledge_store.py
@@ -40,9 +40,9 @@ async def store_knowledge(event: EventEnvelope, context: PlatformContext):
     data = event.data or {}
     content = data.get("content", "")
     metadata = data.get("metadata", {})
-    user_id = event.user_id or "00000000-0000-0000-0000-000000000001"
+    user_id = event.user_id  # User ID from event envelope
     
-    print(f"\n📚 Storing knowledge:")
+    print(f"\n📚 Storing knowledge (user: {user_id}):")
     print(f"   Content: {content[:100]}...")
     print(f"   Metadata: {metadata}")
     

--- a/examples/05-memory-semantic/llm_utils.py
+++ b/examples/05-memory-semantic/llm_utils.py
@@ -62,7 +62,8 @@ async def validate_and_publish(
     events: list[EventDefinition],
     topic: str,
     context: PlatformContext,
-    correlation_id: str = None
+    correlation_id: str = None,
+    user_id: str = None
 ) -> bool:
     """
     Validate LLM's event selection and publish the event.
@@ -75,6 +76,7 @@ async def validate_and_publish(
         topic: Topic to publish to
         context: PlatformContext with EventBus client
         correlation_id: Optional correlation ID for request/response pattern
+        user_id: User ID to propagate in event envelope
     
     Returns:
         True if event was published successfully, False otherwise
@@ -93,6 +95,7 @@ async def validate_and_publish(
         topic=topic,
         data=decision["data"],
         correlation_id=correlation_id,
+        user_id=user_id,  # Propagate user_id
     )
     
     return True

--- a/examples/05-memory-semantic/router.py
+++ b/examples/05-memory-semantic/router.py
@@ -60,8 +60,7 @@ Return your decision in this JSON format:
     "event_name": "knowledge.store" or "question.ask",
     "reasoning": "Brief explanation of why you chose this action",
     "data": {{
-        "content": "..." (for knowledge.store) OR "question": "..." (for question.ask),
-        "user_id": "00000000-0000-0000-0000-000000000001"
+        "content": "..." (for knowledge.store) OR "question": "..." (for question.ask)
     }}
 }}
 
@@ -116,7 +115,8 @@ async def route_request(event: EventEnvelope, context: PlatformContext):
         events=action_events,
         topic=EventTopic.ACTION_REQUESTS,
         context=context,
-        correlation_id=event.correlation_id
+        correlation_id=event.correlation_id,
+        user_id=event.user_id  # Propagate user_id from incoming event
     )
     
     if success:

--- a/examples/06-memory-episodic/knowledge_store.py
+++ b/examples/06-memory-episodic/knowledge_store.py
@@ -60,10 +60,11 @@ async def store_knowledge(event: EventEnvelope, context: PlatformContext):
     session_id = data.get("session_id")
     
     tenant_id = event.tenant_id or "00000000-0000-0000-0000-000000000000"
-    user_id = event.user_id or "00000000-0000-0000-0000-000000000001"
+    user_id = event.user_id  # User ID from event envelope
     
     print(f"\n📚 Knowledge Store Processing")
     print(f"   Session: {session_id}")
+    print(f"   User: {user_id}")
     print(f"   Message: {message[:80]}...")
     
     # Extract fact


### PR DESCRIPTION
Changes:
- Example 05 & 06: Use event.user_id instead of hardcoding
- Client publishes user_id in event envelope (default UUID)
- All agents propagate user_id when publishing events
- Updated README with user privacy isolation testing guide

User-scoped privacy now properly enforced through event chain. See examples/05-memory-semantic/README.md for testing guide.