### PR TITLE
feat(soorma-common): add platform tenant ID constant and EventEnvelope field

### DIFF
--- a/aidlc-docs/platform/multi-tenancy/aidlc-state.md
+++ b/aidlc-docs/platform/multi-tenancy/aidlc-state.md
@@ -6,7 +6,7 @@
 - **Functional Area**: platform
 - **Feature**: multi-tenancy
 - **Start Date**: 2026-03-21T23:01:10Z
-- **Current Stage**: CONSTRUCTION - U1 (soorma-common) - Construction Design PR Gate PENDING (branch: dev); awaiting team approval before Code Generation
+- **Current Stage**: CONSTRUCTION - U1 (soorma-common) - Code Generation COMPLETE
 
 ## Workspace State
 - **Existing Code**: Yes
@@ -44,8 +44,9 @@
 #### U1 — soorma-common (Wave 1)
 - [x] Unit Initialization
 - [x] Functional Design (artifacts at construction/soorma-common/functional-design/)
-- [x] Code Generation Plan (construction/plans/soorma-common-code-generation-plan.md) — awaiting approval
-- [ ] Code Generation (execution)
+- [x] Code Generation Plan (construction/plans/soorma-common-code-generation-plan.md) — APPROVED
+- [x] Construction Design PR Gate (dev branch — APPROVED 2026-03-22T07:33:32Z)
+- [x] Code Generation (execution) — COMPLETE 2026-03-22 | 112/112 tests pass
 
 #### U2 — soorma-service-common (Wave 2) — blocked on U1
 #### U3 — services/registry (Wave 2) — blocked on U1
@@ -69,8 +70,8 @@
 - **Approved**: 2026-03-22T07:18:48Z
 
 ### Construction Design PR Gate — soorma-common
-- **Status**: PENDING
+- **Status**: APPROVED
 - **Branch**: dev
 - **Instructions**: aidlc-docs/platform/multi-tenancy/construction/plans/soorma-common-design-pr-checkpoint-instructions.md
 - **Created**: 2026-03-22T07:28:46Z
-- **Approved**: —
+- **Approved**: 2026-03-22T07:33:32Z

--- a/aidlc-docs/platform/multi-tenancy/audit.md
+++ b/aidlc-docs/platform/multi-tenancy/audit.md
@@ -148,3 +148,27 @@
 **Context**: CONSTRUCTION PHASE -- Unit soorma-common -- Construction Design PR Gate PENDING; Code Generation BLOCKED
 
 ---
+
+## Construction Design PR Gate Approved -- soorma-common (U1)
+**Timestamp**: 2026-03-22T07:33:32Z
+**User Input**: "PR approved"
+**AI Response**: Construction Design PR Gate for soorma-common marked APPROVED. aidlc-state.md updated: gate status APPROVED, approved timestamp 2026-03-22T07:33:32Z. Code Generation is now unblocked. Proceeding to Code Generation Part 2 execution.
+**Context**: CONSTRUCTION PHASE -- Unit soorma-common -- Code Generation UNBLOCKED; executing plan
+
+---
+
+## Code Generation - U1 soorma-common - COMPLETE
+**Timestamp**: 2026-03-22T07:46:25Z
+**User Input**: "need to source ~/ws/github/soorma-ai/soorma-core/.venv/bin/activate before running any python commands"
+**AI Response**: Resumed RED phase with venv activated. Confirmed RED (3 AssertionError failures, 2 structural passes). Implemented GREEN for tenancy.py (os.environ.get or sentinel). Added 4 RED tests for EventEnvelope.platform_tenant_id (AttributeError confirmed). Implemented GREEN for events.py (platform_tenant_id field + updated tenant_id/user_id docstrings). Added __init__.py export. REFACTOR verified (only os import, no UUID validation). Full suite: 112/112 pass. code-summary.md created. aidlc-state.md updated: U1 Code Generation COMPLETE.
+**Context**: Code Generation Steps 2-8 completed. U1 soorma-common fully done.
+
+---
+
+## Code Generation - U1 soorma-common - COMPLETE
+**Timestamp**: 2026-03-22T07:47:02Z
+**User Input**: "need to source .venv/bin/activate before running any python commands"
+**AI Response**: Resumed RED phase with venv activated. Confirmed RED (3 AssertionError failures). Implemented GREEN tenancy.py. Added 4 RED tests for EventEnvelope.platform_tenant_id (AttributeError confirmed). Implemented GREEN events.py (platform_tenant_id field + updated docstrings). Added __init__.py export. REFACTOR: 112/112 pass. code-summary.md created. U1 COMPLETE.
+**Context**: Code Generation Steps 2-8 all complete for U1 soorma-common.
+
+---

--- a/aidlc-docs/platform/multi-tenancy/construction/plans/soorma-common-code-generation-plan.md
+++ b/aidlc-docs/platform/multi-tenancy/construction/plans/soorma-common-code-generation-plan.md
@@ -37,71 +37,71 @@ This unit uses the **soorma-core TDD mandate**: all steps must follow STUB → R
 ## Steps
 
 ### Step 1: STUB — Create `soorma_common/tenancy.py` (stub)
-- [ ] Create `libs/soorma-common/src/soorma_common/tenancy.py`
-- [ ] Define `DEFAULT_PLATFORM_TENANT_ID: str = ""` (stub — wrong value, tests will fail)
-- [ ] Include the required code comment warning (NFR-3.3)
-- [ ] Verify module imports without error
+- [x] Create `libs/soorma-common/src/soorma_common/tenancy.py`
+- [x] Define `DEFAULT_PLATFORM_TENANT_ID: str = ""` (stub — wrong value, tests will fail)
+- [x] Include the required code comment warning (NFR-3.3)
+- [x] Verify module imports without error
 
 **Target file**: `libs/soorma-common/src/soorma_common/tenancy.py`
 
 ---
 
 ### Step 2: RED — Write `test_tenancy.py` (tests must FAIL against stub)
-- [ ] Create `libs/soorma-common/tests/test_tenancy.py`
-- [ ] Write `TestDefaultPlatformTenantId`:
+- [x] Create `libs/soorma-common/tests/test_tenancy.py`
+- [x] Write `TestDefaultPlatformTenantId`:
   - `test_default_value` — asserts value equals `"spt_00000000-0000-0000-0000-000000000000"` (FAILS against stub `""`)
   - `test_env_var_override` — monkeypatches `SOORMA_PLATFORM_TENANT_ID`, reimports module, asserts override value is used
   - `test_env_var_empty_uses_default` — env var set to `""` → falls back to literal default
-- [ ] Run tests: verify they **FAIL** with assertion errors (not ImportError/AttributeError)
+- [x] Run tests: verify they **FAIL** with assertion errors (not ImportError/AttributeError)
 
 **Target file**: `libs/soorma-common/tests/test_tenancy.py`
 
 ---
 
 ### Step 3: GREEN — Implement `tenancy.py` (real logic, tests must PASS)
-- [ ] Replace stub value with real env var resolution logic in `tenancy.py`
-- [ ] Run `test_tenancy.py`: verify all tests **PASS**
+- [x] Replace stub value with real env var resolution logic in `tenancy.py`
+- [x] Run `test_tenancy.py`: verify all tests **PASS**
 
 ---
 
 ### Step 4: STUB — `EventEnvelope` field not yet added (RED state for new tests)
-- [ ] Write new test methods in `libs/soorma-common/tests/test_events.py`:
+- [x] Write new test methods in `libs/soorma-common/tests/test_events.py`:
   - `test_platform_tenant_id_defaults_to_none` — creates `EventEnvelope` without `platform_tenant_id`, asserts field is `None`
   - `test_platform_tenant_id_accepts_opaque_string` — sets `platform_tenant_id="spt_test-123"`, asserts value stored correctly
   - `test_platform_tenant_id_backward_compatible` — existing minimal envelope construction still works (no required field added)
   - `test_tenant_id_field_semantics` — verify `tenant_id` is optional string (existing field, docstring context test)
-- [ ] Run the new tests: they must **FAIL** with `AttributeError: 'EventEnvelope' has no attribute 'platform_tenant_id'`
+- [x] Run the new tests: they must **FAIL** with `AttributeError: 'EventEnvelope' has no attribute 'platform_tenant_id'`
 
 ---
 
 ### Step 5: GREEN — Add `platform_tenant_id` field to `EventEnvelope`
-- [ ] Modify `libs/soorma-common/src/soorma_common/events.py`:
+- [x] Modify `libs/soorma-common/src/soorma_common/events.py`:
   - Add `platform_tenant_id: Optional[str]` field adjacent to `tenant_id` / `user_id`
   - Update `platform_tenant_id` field docstring: "Platform tenant ID — injected by Event Service from authenticated X-Tenant-ID header at publish time. SDK agents MUST NOT set this field; any value will be overwritten by the Event Service."
   - Update `tenant_id` field docstring: "Service tenant ID — SDK-supplied. Identifies the tenant within the service layer (e.g., memory, tracker). Distinct from `platform_tenant_id`. Passed through the event bus unchanged."
   - Update `user_id` field docstring: "Service user ID — SDK-supplied. Identifies the user within the service tenant context. Passed through the event bus unchanged."
-- [ ] Run all `test_events.py` tests: new tests **PASS**, existing tests still **PASS**
+- [x] Run all `test_events.py` tests: new tests **PASS**, existing tests still **PASS**
 
 ---
 
 ### Step 6: GREEN — Export `DEFAULT_PLATFORM_TENANT_ID` from `__init__.py`
-- [ ] Modify `libs/soorma-common/src/soorma_common/__init__.py`:
+- [x] Modify `libs/soorma-common/src/soorma_common/__init__.py`:
   - Add `from .tenancy import DEFAULT_PLATFORM_TENANT_ID` (import from new module)
   - Add `DEFAULT_PLATFORM_TENANT_ID` to the public exports block
-- [ ] Verify import: `from soorma_common import DEFAULT_PLATFORM_TENANT_ID` resolves correctly
+- [x] Verify import: `from soorma_common import DEFAULT_PLATFORM_TENANT_ID` resolves correctly
 
 ---
 
 ### Step 7: REFACTOR — Review and clean up
-- [ ] Review `tenancy.py` for clarity: ensure code comment warning is prominent
-- [ ] Verify no UUID format validation was accidentally introduced
-- [ ] Verify `tenancy.py` imports only `os` (no FastAPI/Starlette/SQLAlchemy)
-- [ ] Run full test suite: `pytest libs/soorma-common/tests/` — all tests pass
+- [x] Review `tenancy.py` for clarity: ensure code comment warning is prominent
+- [x] Verify no UUID format validation was accidentally introduced
+- [x] Verify `tenancy.py` imports only `os` (no FastAPI/Starlette/SQLAlchemy)
+- [x] Run full test suite: `pytest libs/soorma-common/tests/` — all tests pass (112/112)
 
 ---
 
 ### Step 8: Code Summary
-- [ ] Create `aidlc-docs/platform/multi-tenancy/construction/soorma-common/code/code-summary.md`
+- [x] Create `aidlc-docs/platform/multi-tenancy/construction/soorma-common/code/code-summary.md`
   - List all modified and created files with purpose
   - Note test execution results (expected: all pass)
 

--- a/aidlc-docs/platform/multi-tenancy/construction/soorma-common/code/code-summary.md
+++ b/aidlc-docs/platform/multi-tenancy/construction/soorma-common/code/code-summary.md
@@ -1,0 +1,81 @@
+# Code Summary — U1: soorma-common
+## Initiative: Multi-Tenancy Model Implementation
+**Unit**: U1 — `libs/soorma-common`
+**Wave**: 1 (no dependencies)
+**Completed**: 2026-03-22
+**Branch**: dev
+
+---
+
+## Requirements Implemented
+
+| Requirement | Description | Status |
+|---|---|---|
+| FR-1.1 | `DEFAULT_PLATFORM_TENANT_ID` constant | ✅ |
+| FR-1.2 | `SOORMA_PLATFORM_TENANT_ID` env var override | ✅ |
+| FR-1.3 | Code comment warning against production use | ✅ |
+| FR-1.4 | No format validation on IDs | ✅ |
+| FR-6.1 | `EventEnvelope.platform_tenant_id` field defaults to `None` | ✅ |
+| FR-6.2 | Field accepts opaque string values | ✅ |
+| FR-6.3 | Backward compatible — existing envelope construction unchanged | ✅ |
+| FR-6.4 | `tenant_id` and `platform_tenant_id` are distinct fields | ✅ |
+| NFR-3.2 | Opaque string, no UUID validation | ✅ |
+| NFR-3.3 | Deprecation warning as code comment | ✅ |
+
+---
+
+## Files Changed
+
+### New Files
+
+| File | Description |
+|---|---|
+| `libs/soorma-common/src/soorma_common/tenancy.py` | New module — provides `DEFAULT_PLATFORM_TENANT_ID` constant with `SOORMA_PLATFORM_TENANT_ID` env var override. Sentinel value: `spt_00000000-0000-0000-0000-000000000000`. Imports only `os`. |
+| `libs/soorma-common/tests/test_tenancy.py` | TDD tests for `tenancy.py` — 5 tests covering default value, env var override, empty env var fallback, type assertion, and no-framework-import constraint. |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `libs/soorma-common/src/soorma_common/events.py` | Added `platform_tenant_id: Optional[str] = Field(default=None, ...)` to `EventEnvelope` adjacent to `tenant_id`/`user_id`. Updated docstrings for `tenant_id` and `user_id` to clarify service-layer scope vs platform-layer scope. |
+| `libs/soorma-common/src/soorma_common/__init__.py` | Added `from .tenancy import DEFAULT_PLATFORM_TENANT_ID` export. |
+| `libs/soorma-common/tests/test_events.py` | Added 4 new tests to `TestEventEnvelope`: `test_platform_tenant_id_defaults_to_none`, `test_platform_tenant_id_accepts_opaque_string`, `test_platform_tenant_id_backward_compatible`, `test_tenant_id_field_semantics`. |
+
+---
+
+## Test Results
+
+```
+112 passed in 0.33s
+```
+
+All 112 tests pass. No regressions.
+
+### New Tests Added
+- `tests/test_tenancy.py` — 5 tests (new file)
+- `tests/test_events.py` — 4 tests added to `TestEventEnvelope`
+
+---
+
+## Downstream Contracts Locked
+
+These artifacts are now stable and consumed by downstream units:
+
+| Contract | Consumed By |
+|---|---|
+| `DEFAULT_PLATFORM_TENANT_ID` constant (exported from `soorma_common`) | U2 (soorma-service-common), U3 (services/registry), U4 (services/event), U5 (services/memory), U6 (sdk) |
+| `EventEnvelope.platform_tenant_id: Optional[str]` field | U5 (services/memory), U7 if applicable |
+
+---
+
+## TDD Cycle Executed
+
+| Step | Action | Result |
+|---|---|---|
+| STUB | `tenancy.py` with `DEFAULT_PLATFORM_TENANT_ID = ""` | Imports without error |
+| RED | `test_tenancy.py` — 3 fail (AssertionError), 2 pass structural tests | Confirmed RED |
+| GREEN | Implemented `os.environ.get(...) or "spt_..."` | 5/5 pass |
+| STUB | 4 new `test_events.py` tests before field added | Confirmed RED (AttributeError) |
+| GREEN | Added `platform_tenant_id` field to `EventEnvelope`; updated docstrings | 24/24 pass |
+| GREEN | Exported `DEFAULT_PLATFORM_TENANT_ID` from `__init__.py` | Export resolves correctly |
+| REFACTOR | Verified no UUID validation, no framework imports in `tenancy.py`, full suite | 112/112 pass |

--- a/libs/soorma-common/src/soorma_common/__init__.py
+++ b/libs/soorma-common/src/soorma_common/__init__.py
@@ -98,6 +98,8 @@ from .tracking import (
     TaskStateChanged,
 )
 
+from .tenancy import DEFAULT_PLATFORM_TENANT_ID
+
 from .tracker import (
     # Tracker Service Response DTOs
     PlanProgress,

--- a/libs/soorma-common/src/soorma_common/events.py
+++ b/libs/soorma-common/src/soorma_common/events.py
@@ -99,11 +99,15 @@ class EventEnvelope(BaseDTO):
     # Additional Soorma-specific metadata
     tenant_id: Optional[str] = Field(
         default=None,
-        description="Tenant ID for multi-tenancy"
+        description="Service tenant ID — SDK-supplied. Identifies the tenant within the service layer (e.g., memory, tracker). Distinct from `platform_tenant_id`. Passed through the event bus unchanged."
     )
     user_id: Optional[str] = Field(
         default=None,
-        description="User ID for user-specific events"
+        description="Service user ID — SDK-supplied. Identifies the user within the service tenant context. Passed through the event bus unchanged."
+    )
+    platform_tenant_id: Optional[str] = Field(
+        default=None,
+        description="Platform tenant ID — injected by Event Service from authenticated X-Tenant-ID header at publish time. SDK agents MUST NOT set this field; any value will be overwritten by the Event Service."
     )
     session_id: Optional[str] = Field(
         default=None,

--- a/libs/soorma-common/src/soorma_common/tenancy.py
+++ b/libs/soorma-common/src/soorma_common/tenancy.py
@@ -1,0 +1,16 @@
+"""
+Platform tenancy constants for Soorma.
+
+Provides the default platform tenant ID used throughout soorma-core for
+development and testing. Override via the SOORMA_PLATFORM_TENANT_ID env var.
+"""
+
+import os
+
+# WARNING: For development/testing only.
+# MUST NOT be used in production once the Identity Service is implemented.
+# At that point, all platform_tenant_id values must come from authenticated
+# Identity Service tokens — never from this constant.
+DEFAULT_PLATFORM_TENANT_ID: str = (
+    os.environ.get("SOORMA_PLATFORM_TENANT_ID") or "spt_00000000-0000-0000-0000-000000000000"
+)

--- a/libs/soorma-common/tests/test_events.py
+++ b/libs/soorma-common/tests/test_events.py
@@ -176,6 +176,54 @@ class TestEventEnvelope:
         assert ce_dict["responsetopic"] == "action-results"
         assert ce_dict["payloadschemaname"] == "test_schema_v1"
 
+    def test_platform_tenant_id_defaults_to_none(self):
+        """platform_tenant_id is None when not explicitly provided (FR-6.1)."""
+        envelope = EventEnvelope(
+            source="test-agent",
+            type="test.event",
+            topic=EventTopic.BUSINESS_FACTS,
+        )
+        assert envelope.platform_tenant_id is None
+
+    def test_platform_tenant_id_accepts_opaque_string(self):
+        """platform_tenant_id stores any opaque string value (NFR-3.2, FR-6.2)."""
+        envelope = EventEnvelope(
+            source="test-agent",
+            type="test.event",
+            topic=EventTopic.BUSINESS_FACTS,
+            platform_tenant_id="spt_test-123",
+        )
+        assert envelope.platform_tenant_id == "spt_test-123"
+
+    def test_platform_tenant_id_backward_compatible(self):
+        """Existing envelope construction without platform_tenant_id still works (FR-6.3)."""
+        envelope = EventEnvelope(
+            source="test-agent",
+            type="test.event",
+            topic=EventTopic.ACTION_REQUESTS,
+            data={"key": "value"},
+            tenant_id="tenant-1",
+            user_id="user-1",
+        )
+        # No AttributeError — field exists and defaults to None
+        assert envelope.platform_tenant_id is None
+        # Existing fields unaffected
+        assert envelope.tenant_id == "tenant-1"
+        assert envelope.user_id == "user-1"
+
+    def test_tenant_id_field_semantics(self):
+        """tenant_id and platform_tenant_id are distinct fields with independent values (FR-6.4)."""
+        envelope = EventEnvelope(
+            source="test-agent",
+            type="test.event",
+            topic=EventTopic.BUSINESS_FACTS,
+            tenant_id="service-tenant-abc",
+            platform_tenant_id="spt_00000000-0000-0000-0000-000000000000",
+        )
+        assert envelope.tenant_id == "service-tenant-abc"
+        assert envelope.platform_tenant_id == "spt_00000000-0000-0000-0000-000000000000"
+        assert envelope.tenant_id != envelope.platform_tenant_id
+
 
 class TestActionRequestEvent:
     """Tests for ActionRequestEvent model."""

--- a/libs/soorma-common/tests/test_tenancy.py
+++ b/libs/soorma-common/tests/test_tenancy.py
@@ -1,0 +1,66 @@
+"""
+Tests for soorma_common.tenancy module.
+
+TDD RED phase: these tests assert the REAL expected behaviour and will FAIL
+against the stub (DEFAULT_PLATFORM_TENANT_ID = "").
+"""
+import importlib
+import os
+
+import pytest
+
+import soorma_common.tenancy as tenancy_module
+
+
+class TestDefaultPlatformTenantId:
+    """Tests for DEFAULT_PLATFORM_TENANT_ID constant resolution."""
+
+    def test_default_value(self):
+        """DEFAULT_PLATFORM_TENANT_ID equals the canonical dev/test sentinel when env var is absent."""
+        # Reload without env var override to isolate
+        env_backup = os.environ.pop("SOORMA_PLATFORM_TENANT_ID", None)
+        try:
+            importlib.reload(tenancy_module)
+            assert tenancy_module.DEFAULT_PLATFORM_TENANT_ID == "spt_00000000-0000-0000-0000-000000000000"
+        finally:
+            if env_backup is not None:
+                os.environ["SOORMA_PLATFORM_TENANT_ID"] = env_backup
+            importlib.reload(tenancy_module)
+
+    def test_env_var_override(self, monkeypatch):
+        """SOORMA_PLATFORM_TENANT_ID env var takes precedence over the literal default."""
+        monkeypatch.setenv("SOORMA_PLATFORM_TENANT_ID", "spt_custom-tenant-abc")
+        importlib.reload(tenancy_module)
+        assert tenancy_module.DEFAULT_PLATFORM_TENANT_ID == "spt_custom-tenant-abc"
+        # reload once more to restore default state after monkeypatch cleanup
+        importlib.reload(tenancy_module)
+
+    def test_env_var_empty_string_falls_back_to_default(self, monkeypatch):
+        """Empty string env var falls back to the literal default (falsy check)."""
+        monkeypatch.setenv("SOORMA_PLATFORM_TENANT_ID", "")
+        importlib.reload(tenancy_module)
+        assert tenancy_module.DEFAULT_PLATFORM_TENANT_ID == "spt_00000000-0000-0000-0000-000000000000"
+        importlib.reload(tenancy_module)
+
+    def test_no_format_validation(self):
+        """DEFAULT_PLATFORM_TENANT_ID is a plain str — no UUID or pattern validation."""
+        # Any string value should be accepted as opaque (NFR-3.2)
+        assert isinstance(tenancy_module.DEFAULT_PLATFORM_TENANT_ID, str)
+
+    def test_no_framework_imports(self):
+        """tenancy module MUST only import from stdlib (SDK compatibility — C1 boundary)."""
+        import soorma_common.tenancy as mod
+        import sys
+
+        # Collect imports by inspecting module's globals for imported modules
+        forbidden = {"fastapi", "starlette", "sqlalchemy", "httpx"}
+        module_imports = {
+            name
+            for name, obj in vars(mod).items()
+            if isinstance(obj, type(os)) and hasattr(obj, "__name__")
+        }
+        # Also check sys.modules for anything pulled in transitively
+        for forbidden_pkg in forbidden:
+            assert forbidden_pkg not in sys.modules or mod.__name__ not in sys.modules.get(
+                forbidden_pkg, object
+            ).__dict__, f"tenancy.py must not import {forbidden_pkg}"


### PR DESCRIPTION
Closes #54

- Add DEFAULT_PLATFORM_TENANT_ID with SOORMA_PLATFORM_TENANT_ID env var override
- Add platform_tenant_id field to EventEnvelope (injected by Event Service)
- Update tenant_id and user_id field docstrings to clarify service vs platform scope
- Export DEFAULT_PLATFORM_TENANT_ID from soorma_common __init__
- 112/112 tests pass