### PR TITLE
uow-cutover-hardening: cutover and hardening

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -201,9 +201,10 @@ from soorma.memory.client import MemoryServiceClient  # FORBIDDEN
 
 **Non-Negotiable Rules:**
 
-1. **Service Clients:** MUST include authentication headers (`X-Tenant-ID`, `X-User-ID`) on **every request**
-   - No exceptions. Missing headers = 403 Forbidden by design.
-   - Service client methods validate headers are present
+1. **Service Clients:** MUST authenticate every secured request explicitly
+   - Use `Authorization: Bearer <token>` for Registry, Memory, Tracker, and Event service traffic.
+   - Identity-service admin routes may additionally use explicit admin headers where documented.
+   - Missing bearer auth on secured routes fails closed.
 2. **Wrappers:** MUST extract tenant/user context **automatically** from event envelope
    - Agent handlers NEVER pass tenant_id/user_id manually
    - Wrapper methods have NO tenant_id/user_id parameters
@@ -213,8 +214,8 @@ from soorma.memory.client import MemoryServiceClient  # FORBIDDEN
    - Service middleware MUST set PostgreSQL session variables (`app.tenant_id`, `app.user_id`)
    - Queries execute within RLS policy scope—automatic enforcement, no manual filtering
 
-**Current State:** v0.7.x uses custom headers (development-only pattern)  
-**Future State:** v0.8.0+ will use JWT/API Keys (production-ready)  
+**Current State:** v0.8.x uses bearer JWTs for secured service traffic, with explicit admin-header exceptions only where documented.  
+**Future State:** v0.9.0+ may add selective API-key flows, but bearer-authenticated runtime traffic remains the baseline.  
 
 **Implementation Details & Migration Roadmap:** See [docs/ARCHITECTURE_PATTERNS.md Section 1](docs/ARCHITECTURE_PATTERNS.md#1-authentication--authorization-current-implementation)
 

--- a/aidlc-docs/platform/identity-service/aidlc-state.md
+++ b/aidlc-docs/platform/identity-service/aidlc-state.md
@@ -3,7 +3,7 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-04-01T00:38:43Z
-- **Current Stage**: CONSTRUCTION - Design PR Gate Branch Confirmation (uow-cutover-hardening)
+- **Current Stage**: CONSTRUCTION - Code Generation Plan Approval (uow-cutover-hardening)
 
 ## Workspace State
 - **Existing Code**: Yes
@@ -51,9 +51,9 @@
 
 ## Current Status
 - **Lifecycle Phase**: CONSTRUCTION
-- **Current Stage**: Construction Design PR Gate Pending Approval - uow-cutover-hardening
+- **Current Stage**: Code Generation Plan Approval - uow-cutover-hardening
 - **Next Stage**: Code Generation - uow-cutover-hardening
-- **Status**: Construction design PR checkpoint instructions were generated for uow-cutover-hardening on branch dev; awaiting team review and explicit PR approval confirmation before code generation
+- **Status**: Code Generation Part 1 plan for uow-cutover-hardening is complete at construction/plans/uow-cutover-hardening-code-generation-plan.md and is awaiting explicit approval before Part 2 execution
 
 ## Units Generation Status
 - [x] Units Planning - Completed
@@ -90,11 +90,11 @@
 - **Approved**: 2026-04-13T22:05:49Z
 
 ### Construction Design PR Gate - uow-cutover-hardening
-- **Status**: PENDING
+- **Status**: APPROVED
 - **Branch**: dev
 - **Instructions**: aidlc-docs/platform/identity-service/construction/plans/uow-cutover-hardening-design-pr-checkpoint-instructions.md
 - **Created**: 2026-04-15T05:16:43Z
-- **Approved**: —
+- **Approved**: 2026-04-15T05:24:14Z
 
 ## Reverse Engineering Status
 - [x] Reverse Engineering - Completed on 2026-04-01T00:42:04Z

--- a/aidlc-docs/platform/identity-service/aidlc-state.md
+++ b/aidlc-docs/platform/identity-service/aidlc-state.md
@@ -53,7 +53,7 @@
 - **Lifecycle Phase**: CONSTRUCTION
 - **Current Stage**: Code Generation Review - uow-cutover-hardening
 - **Next Stage**: Build and Test (pending explicit approval for uow-cutover-hardening)
-- **Status**: Code Generation execution for uow-cutover-hardening is complete, including the second review-driven correction pass for bearer-only Tier-2 transport, shared example token-provider reuse, and canonical JWT service-identity fallback; the unit is awaiting explicit review-gate approval before Build and Test
+- **Status**: Code Generation execution for uow-cutover-hardening is complete, including the review-driven correction passes for bearer-only Tier-2 transport, shared example token-provider reuse, canonical JWT service-identity fallback, bootstrap-derived platform-tenant propagation, post-onboarding identity-client binding, and removal of low-level identity-client caller-JWT self-generation; the unit is awaiting explicit review-gate approval before Build and Test
 
 ## Units Generation Status
 - [x] Units Planning - Completed

--- a/aidlc-docs/platform/identity-service/aidlc-state.md
+++ b/aidlc-docs/platform/identity-service/aidlc-state.md
@@ -53,7 +53,7 @@
 - **Lifecycle Phase**: CONSTRUCTION
 - **Current Stage**: Code Generation Review - uow-cutover-hardening
 - **Next Stage**: Build and Test (pending explicit approval for uow-cutover-hardening)
-- **Status**: Code Generation execution for uow-cutover-hardening is complete and awaiting explicit review-gate approval before Build and Test
+- **Status**: Code Generation execution for uow-cutover-hardening is complete, including the second review-driven correction pass for bearer-only Tier-2 transport, shared example token-provider reuse, and canonical JWT service-identity fallback; the unit is awaiting explicit review-gate approval before Build and Test
 
 ## Units Generation Status
 - [x] Units Planning - Completed

--- a/aidlc-docs/platform/identity-service/aidlc-state.md
+++ b/aidlc-docs/platform/identity-service/aidlc-state.md
@@ -3,7 +3,7 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-04-01T00:38:43Z
-- **Current Stage**: CONSTRUCTION - Code Generation Plan Approval (uow-cutover-hardening)
+- **Current Stage**: CONSTRUCTION - Code Generation Review (uow-cutover-hardening)
 
 ## Workspace State
 - **Existing Code**: Yes
@@ -51,9 +51,9 @@
 
 ## Current Status
 - **Lifecycle Phase**: CONSTRUCTION
-- **Current Stage**: Code Generation Plan Approval - uow-cutover-hardening
-- **Next Stage**: Code Generation - uow-cutover-hardening
-- **Status**: Code Generation Part 1 plan for uow-cutover-hardening is complete at construction/plans/uow-cutover-hardening-code-generation-plan.md and is awaiting explicit approval before Part 2 execution
+- **Current Stage**: Code Generation Review - uow-cutover-hardening
+- **Next Stage**: Build and Test (pending explicit approval for uow-cutover-hardening)
+- **Status**: Code Generation execution for uow-cutover-hardening is complete and awaiting explicit review-gate approval before Build and Test
 
 ## Units Generation Status
 - [x] Units Planning - Completed

--- a/aidlc-docs/platform/identity-service/audit.md
+++ b/aidlc-docs/platform/identity-service/audit.md
@@ -26,6 +26,30 @@ for tenant's identity service's users, following namespace convention is expecte
 
 ---
 
+## Code Generation - Shim Removal Cleanup
+**Timestamp**: 2026-04-15T08:37:30Z
+**User Input**: "yes, remove the shim"
+**AI Response**: "Removed the example-local auth_bootstrap adapter from 01-hello-world, wired the example scripts directly to examples.shared.auth with explicit example-name binding, added a shared CLI entrypoint for start.sh priming, updated focused tests and docs, and verified the cleanup with 51 focused SDK/example tests passing."
+**Context**: CONSTRUCTION - Code Generation review correction refinement
+
+---
+
+## Code Generation - Correction Execution Complete
+**Timestamp**: 2026-04-15T08:15:03Z
+**User Input**: "yes, request changes and implement corrections."
+**AI Response**: "Completed the second review-driven correction pass for uow-cutover-hardening by introducing SDK token-provider/factory support, removing active legacy tenant-header transport from event/registry/memory/tracker bearer-auth flows, propagating providers through PlatformContext and BaseAgent wiring, moving example bootstrap/token logic into examples/shared/auth.py, updating 01-hello-world to use the shared provider, and tightening shared middleware canonical service-identity fallback for bearer-only JWT requests."
+**Context**: CONSTRUCTION - Code Generation review correction
+
+---
+
+## Code Generation - Correction Review Prompt
+**Timestamp**: 2026-04-15T08:15:03Z
+**User Input**: "yes, request changes and implement corrections."
+**AI Response**: "Ran focused validation for the correction pass and confirmed 83 SDK/example tests passed plus 30 shared middleware tests passed. Updated code-generation summary/state artifacts and prepared the renewed standardized Code Generation completion gate for uow-cutover-hardening."
+**Context**: CONSTRUCTION - Code Generation correction approval gate
+
+---
+
 ## Functional Design - Q5 Clarification
 **Timestamp**: 2026-04-04T22:11:41Z
 **User Input**: "help me understand q5 and its options"
@@ -619,6 +643,33 @@ end-to-end without my confirmation at each gate."
 **User Input**: "all questions answered"
 **AI Response**: "Generated finalized requirements document at aidlc-docs/platform/identity-service/inception/requirements/requirements.md, updated extension configuration/status in aidlc-state.md, and presented Requirements Analysis approval gate."
 **Context**: INCEPTION - Requirements Analysis completion prompt
+
+---
+
+## Code Generation - Review Findings
+**Timestamp**: 2026-04-15T07:29:49Z
+**User Input**: "need to think through this change. some initial observations / comments:
+- why are we still using `X-Tenant-ID` in the headers for memory / registry / event clients? they should now only have Authorization header, correct? that's what this unit's hardening scope was, only JWT Auth header, no more legacy tenant headers. only identity service APIs should need api key and x-tenant-id headers.
+- i'm assuming this new #file:auth_bootstrap.py is that \"trusted proxy\" that can request JWT token. BUT, i see that this is ALSO doing bootstrap of a tenant and its principal. this needs to be re-usable for all examples, so maybe move this into a shared folder (or parent example directory) and re-use this for each of the example as needed (passing example name as parameter instead of hardcoding to 01-hello-world)
+- i think we need better design pattern for token management with client libraries. they should take a factory method as parameter (e.g. during initialization) and that factory method should be responsible for requesting / caching / refreshing JWT token from tenant's \"trusted proxy\". in the examples, our auth_bootstrap utility can provide this factory method. in production applications, real trusted proxy implementatin will provide this method as library."
+**AI Response**: "Reviewed the latest hello-world JWT integration against the approved hardening scope and architecture patterns. Confirmed three substantive issues: EventClient still emits legacy X-Tenant-ID alongside Authorization, registry auth was conflated with end-user JWT bootstrap and developer-tenant identity, and the new auth_bootstrap helper is too example-specific and mixes one-time provisioning with runtime token acquisition. Recommended a correction pass that keeps Tier-2 services on bearer-only auth, isolates registry/developer auth from client-user JWT flows, and introduces a reusable token-provider abstraction for examples and production trusted-proxy libraries."
+**Context**: CONSTRUCTION - Code Generation review assessment
+
+---
+
+## Code Generation - Request Changes
+**Timestamp**: 2026-04-15T06:35:10Z
+**User Input**: "ok, now our example agents and driver clients are not able to talk to soorma-core infrastructure services ... which is expected because we require JWT auth in API calls. how do they request JWT token and inject into their clients to use that token? lets start with the very first example 01-hello-world"
+**AI Response**: "Accepted the review-driven change request for uow-cutover-hardening and implemented hello-world JWT bootstrap and propagation by adding bearer-auth support to SDK event and registry clients, propagating SOORMA_AUTH_TOKEN through PlatformContext and BaseAgent wiring, creating a persisted example onboarding/token helper under .soorma, updating the hello-world worker/client/startup/docs, and adding focused regression coverage for the new transport and bootstrap behavior."
+**Context**: CONSTRUCTION - Code Generation review correction
+
+---
+
+## Code Generation - Correction Review Prompt
+**Timestamp**: 2026-04-15T06:35:10Z
+**User Input**: "ok, now our example agents and driver clients are not able to talk to soorma-core infrastructure services ... which is expected because we require JWT auth in API calls. how do they request JWT token and inject into their clients to use that token? lets start with the very first example 01-hello-world"
+**AI Response**: "Re-ran the focused SDK regression suite for JWT propagation and example bootstrap behavior, confirmed 40 passing tests, updated the code-generation summary and state, and prepared the renewed Code Generation review gate for uow-cutover-hardening."
+**Context**: CONSTRUCTION - Code Generation correction approval gate
 
 ---
 

--- a/aidlc-docs/platform/identity-service/audit.md
+++ b/aidlc-docs/platform/identity-service/audit.md
@@ -72,6 +72,17 @@ for tenant's identity service's users, following namespace convention is expecte
 
 ---
 
+## Code Generation - Full Example Auth Provider Migration
+**Timestamp**: 2026-04-16T06:42:28Z
+**User Input**: "awsome, now go through all examples and update eachl examples to also support same auth pattern as 01-hello-world example:
+ - start.sh bootstraps tenant for example
+ - driver client uses auth provider in event client initialization
+ - agents and tool suse auth provider in agent / tool initialization"
+**AI Response**: "Migrated the remaining example suite to the shared auth-provider pattern. Added bootstrap priming to all example start scripts, updated internal driver/event clients to use bootstrap-derived tenant and admin-principal identifiers with auth_token_provider injection, wired workers/planners/tools and direct memory/tracker/context utility paths to the shared provider, updated the A2A gateway's internal Registry/Event/Worker paths while leaving its external HTTP demo client unchanged, corrected stale copied metadata in 08-worker-basic/start.sh, and validated the final migrated research-advisor and 13-a2a-gateway Python files with py_compile."
+**Context**: CONSTRUCTION - Code Generation review correction refinement
+
+---
+
 ## Code Generation - Shim Removal Cleanup
 **Timestamp**: 2026-04-15T08:37:30Z
 **User Input**: "yes, remove the shim"

--- a/aidlc-docs/platform/identity-service/audit.md
+++ b/aidlc-docs/platform/identity-service/audit.md
@@ -26,6 +26,33 @@ for tenant's identity service's users, following namespace convention is expecte
 
 ---
 
+## Code Generation - Platform Tenant Binding Correction
+**Timestamp**: 2026-04-15T08:56:58Z
+**User Input**: "ok, so we have some bugs:
+- we CAN NOT be using hard coded platform tenant IDs anywhere (e.g. in EventClient initialization). This is old and incorrect pattern when clients were providing platform tenant id. now, identity service generates platform tenant id during onboarding, and that ID needs to be used.
+- since we are doing bootstrapping in these examples, it should have the platform tenant ID from bootstrap file, and we need that id to be used instead of hard coded tenant ID. so might need to extend the shared bootstrap util in examples to provide method for getting platform tenant ID from bootstrap config
+- the IdentityServiceClient has incorrect initialization / constructor, to provide platform tenant ID. this will NOT work. identity service client CAN NOT know platform tenant ID before bootstrap. it should accept the platform tenant id later, after bootstrap is done, either as a parameter for all other methods, or some kind of binding after bootstrap method."
+**AI Response**: "Implemented the platform-tenant binding correction pass by removing hard-coded platform-tenant usage from the hello-world example, extending examples.shared.auth to expose bootstrapped platform-tenant and bootstrap-admin identifiers, binding the low-level identity client with platform_tenant_id only after onboarding payload is available, and removing hard-coded platform-tenant fallbacks from low-level event/memory/tracker constructors. Verified the focused regression slice with 28 passing tests across shared bootstrap helpers, identity client contracts, and event-client auth behavior."
+**Context**: CONSTRUCTION - Code Generation review correction refinement
+
+---
+
+## Code Generation - Identity Client Auth Transport Cleanup
+**Timestamp**: 2026-04-15T09:17:41Z
+**User Input**: "ok, so we cannot be using symmetric shared secret to self generate JWT -- that is wrong as per out current architecture and design. this needs to be removed. for now, all identity methods should just use the platform tenant (from binding) and admin API key. don't need JWT."
+**AI Response**: "Removed low-level identity-client caller-JWT synthesis and related compatibility transport behavior so identity admin requests now carry only `X-Identity-Admin-Key` plus optional bound `X-Tenant-ID`. Updated the focused identity-client tests to match that contract and verified the final regression slice with 27 passing tests across identity-client, shared example auth bootstrap, and event-client registration coverage."
+**Context**: CONSTRUCTION - Code Generation review correction refinement
+
+---
+
+## Code Generation - Renewed Approval Prompt
+**Timestamp**: 2026-04-15T09:17:41Z
+**User Input**: "ok, so we cannot be using symmetric shared secret to self generate JWT -- that is wrong as per out current architecture and design. this needs to be removed. for now, all identity methods should just use the platform tenant (from binding) and admin API key. don't need JWT."
+**AI Response**: "Final review-driven correction pass is complete for uow-cutover-hardening. A renewed Code Generation completion gate will be presented next, with the unit remaining blocked from Build and Test until explicit approval is received."
+**Context**: CONSTRUCTION - Code Generation approval gate
+
+---
+
 ## Code Generation - Shim Removal Cleanup
 **Timestamp**: 2026-04-15T08:37:30Z
 **User Input**: "yes, remove the shim"

--- a/aidlc-docs/platform/identity-service/audit.md
+++ b/aidlc-docs/platform/identity-service/audit.md
@@ -218,6 +218,114 @@ for tenant's identity service's users, following namespace convention is expecte
 
 ---
 
+## Session Continuity - Resume Request
+**Timestamp**: 2026-04-15T05:24:14Z
+**User Input**: "Using AI-DLC, resume construction for unit \"uow-cutover-hardening\" in the identity-service initiative in the platform area. PR for construction design has been approved.
+
+aidlc-state.md is at: aidlc-docs/platform/identity-service/aidlc-state.md
+Project repo: soorma-core
+
+Intent: resume Construction for unit \"uow-cutover-hardening\". Inception is complete.
+Please load all Inception artifacts and begin the Construction phase for this unit.
+
+Follow all AI-DLC approval gates. Stop after each phase, present the completion
+message, and wait for my explicit approval before proceeding. Do not execute
+end-to-end without my confirmation at each gate."
+**AI Response**: "Resumed workflow context from aidlc-state.md, reloaded mandatory common rules, architecture patterns, enabled extension rules, and prior inception and unit-design artifacts required for construction-stage continuity."
+**Context**: Session continuity - construction resume intake
+
+---
+
+## Construction Phase Initialization
+**Timestamp**: 2026-04-15T05:24:14Z
+**User Input**: "Using AI-DLC, resume construction for unit \"uow-cutover-hardening\" in the identity-service initiative in the platform area. PR for construction design has been approved.
+
+aidlc-state.md is at: aidlc-docs/platform/identity-service/aidlc-state.md
+Project repo: soorma-core
+
+Intent: resume Construction for unit \"uow-cutover-hardening\". Inception is complete.
+Please load all Inception artifacts and begin the Construction phase for this unit.
+
+Follow all AI-DLC approval gates. Stop after each phase, present the completion
+message, and wait for my explicit approval before proceeding. Do not execute
+end-to-end without my confirmation at each gate."
+**AI Response**: "Construction Phase Initialization: loaded extension rules for [JIRA Tickets, Team Collaboration Review Gates, QA Test Cases, Security Baseline]."
+**Context**: CONSTRUCTION - phase initialization (session reload)
+
+---
+
+## Unit Initialization
+**Timestamp**: 2026-04-15T05:24:14Z
+**User Input**: "Using AI-DLC, resume construction for unit \"uow-cutover-hardening\" in the identity-service initiative in the platform area. PR for construction design has been approved.
+
+aidlc-state.md is at: aidlc-docs/platform/identity-service/aidlc-state.md
+Project repo: soorma-core
+
+Intent: resume Construction for unit \"uow-cutover-hardening\". Inception is complete.
+Please load all Inception artifacts and begin the Construction phase for this unit.
+
+Follow all AI-DLC approval gates. Stop after each phase, present the completion
+message, and wait for my explicit approval before proceeding. Do not execute
+end-to-end without my confirmation at each gate."
+**AI Response**: "Unit Initialization: loaded extension rules for [JIRA Tickets, Team Collaboration Review Gates, QA Test Cases, Security Baseline] (unit: uow-cutover-hardening)."
+**Context**: CONSTRUCTION - per-unit initialization (session reload)
+
+---
+
+## PR Checkpoint - Approval Confirmation
+**Timestamp**: 2026-04-15T05:24:14Z
+**User Input**: "Using AI-DLC, resume construction for unit \"uow-cutover-hardening\" in the identity-service initiative in the platform area. PR for construction design has been approved.
+
+aidlc-state.md is at: aidlc-docs/platform/identity-service/aidlc-state.md
+Project repo: soorma-core
+
+Intent: resume Construction for unit \"uow-cutover-hardening\". Inception is complete.
+Please load all Inception artifacts and begin the Construction phase for this unit.
+
+Follow all AI-DLC approval gates. Stop after each phase, present the completion
+message, and wait for my explicit approval before proceeding. Do not execute
+end-to-end without my confirmation at each gate."
+**AI Response**: "Accepted explicit Construction Design PR approval confirmation for uow-cutover-hardening, updated checkpoint state to APPROVED, and unlocked Code Generation planning."
+**Context**: CONSTRUCTION - Team collaboration review gate passed
+
+---
+
+## Code Generation - Planning Start
+**Timestamp**: 2026-04-15T05:27:06Z
+**User Input**: "Using AI-DLC, resume construction for unit \"uow-cutover-hardening\" in the identity-service initiative in the platform area. PR for construction design has been approved.
+
+aidlc-state.md is at: aidlc-docs/platform/identity-service/aidlc-state.md
+Project repo: soorma-core
+
+Intent: resume Construction for unit \"uow-cutover-hardening\". Inception is complete.
+Please load all Inception artifacts and begin the Construction phase for this unit.
+
+Follow all AI-DLC approval gates. Stop after each phase, present the completion
+message, and wait for my explicit approval before proceeding. Do not execute
+end-to-end without my confirmation at each gate."
+**AI Response**: "Started Code Generation Part 1 planning for uow-cutover-hardening using approved inception artifacts, unit design artifacts, migration checklist, current implementation touchpoints, and extension constraints."
+**Context**: CONSTRUCTION - Code Generation Part 1 planning
+
+---
+
+## Code Generation - Plan Approval Prompt
+**Timestamp**: 2026-04-15T05:27:06Z
+**User Input**: "Using AI-DLC, resume construction for unit \"uow-cutover-hardening\" in the identity-service initiative in the platform area. PR for construction design has been approved.
+
+aidlc-state.md is at: aidlc-docs/platform/identity-service/aidlc-state.md
+Project repo: soorma-core
+
+Intent: resume Construction for unit \"uow-cutover-hardening\". Inception is complete.
+Please load all Inception artifacts and begin the Construction phase for this unit.
+
+Follow all AI-DLC approval gates. Stop after each phase, present the completion
+message, and wait for my explicit approval before proceeding. Do not execute
+end-to-end without my confirmation at each gate."
+**AI Response**: "Generated the detailed code-generation plan at aidlc-docs/platform/identity-service/construction/plans/uow-cutover-hardening-code-generation-plan.md, updated plan-level checkboxes through Step 6, and prepared the explicit approval gate for Part 1."
+**Context**: CONSTRUCTION - Code Generation Part 1 approval gate
+
+---
+
 ## Functional Design - Planning Start
 **Timestamp**: 2026-04-04T06:32:01Z
 **User Input**: "approved"

--- a/aidlc-docs/platform/identity-service/audit.md
+++ b/aidlc-docs/platform/identity-service/audit.md
@@ -53,6 +53,25 @@ for tenant's identity service's users, following namespace convention is expecte
 
 ---
 
+## Code Generation - Hello World README Correction
+**Timestamp**: 2026-04-16T06:03:23Z
+**User Input**: "the README of 01-hello-world does not talk about auth provider as concept. also, the minimal psuedo code in README is also out of date."
+**AI Response**: "Updated the hello-world README so the auth-token-provider abstraction is explained as a first-class concept, refreshed the worker and client pseudo-code to match the current example implementation, and aligned the narrative with the current bearer-token bootstrap and injection flow."
+**Context**: CONSTRUCTION - Code Generation review correction refinement
+
+---
+
+## Code Generation - Hello Tool Auth Provider Migration
+**Timestamp**: 2026-04-16T06:10:07Z
+**User Input**: "update 01-hello-tool example to also support same auth pattern as 01-hello-world example:
+- start.sh bootstraps tenant for example
+- drive client uses auth provider in event client initialization
+- agent and tool use auth provider in agent / tool initialization"
+**AI Response**: "Updated 01-hello-tool to match the shared example auth-provider pattern by priming bootstrap/token state in start.sh, injecting the shared provider into the driver client's EventClient, wiring the calculator Tool with the same provider at initialization, removing hard-coded tenant/user constants from the client path, and refreshing the example README plus code-generation summary to reflect the current auth flow."
+**Context**: CONSTRUCTION - Code Generation review correction refinement
+
+---
+
 ## Code Generation - Shim Removal Cleanup
 **Timestamp**: 2026-04-15T08:37:30Z
 **User Input**: "yes, remove the shim"

--- a/aidlc-docs/platform/identity-service/audit.md
+++ b/aidlc-docs/platform/identity-service/audit.md
@@ -326,6 +326,14 @@ end-to-end without my confirmation at each gate."
 
 ---
 
+## Code Generation - Plan Approval
+**Timestamp**: 2026-04-15T05:36:08Z
+**User Input**: "ok, plan looks good"
+**AI Response**: "Accepted explicit approval for uow-cutover-hardening code-generation plan, marked Step 7 complete, and transitioned workflow into Code Generation Part 2 execution."
+**Context**: CONSTRUCTION - Code Generation Part 1 approval gate passed
+
+---
+
 ## Functional Design - Planning Start
 **Timestamp**: 2026-04-04T06:32:01Z
 **User Input**: "approved"
@@ -411,6 +419,38 @@ end-to-end without my confirmation at each gate."
 **User Input**: "units look good"
 **AI Response**: "Accepted units generation approval and initiated end-of-Inception extension steps (QA test cases, JIRA tickets, PR checkpoint)."
 **Context**: INCEPTION - Units Generation approval gate passed
+
+---
+
+## Code Generation - Execution Complete
+**Timestamp**: 2026-04-15T05:55:02Z
+**User Input**: "ok, plan looks good"
+**AI Response**: "Completed Code Generation Part 2 for uow-cutover-hardening by enforcing JWT-only secured ingress with trusted admin-key exception, aligning SDK active bearer-auth behavior, adding canonical tenant_id issuance, switching soorma dev bootstrap to deterministic RS256/JWKS defaults, updating docs/changelogs, producing the code-generation summary artifact, and validating focused SDK/shared-auth/identity-service regression suites."
+**Context**: CONSTRUCTION - Code Generation Part 2 execution
+
+---
+
+## Code Generation - Approval Prompt
+**Timestamp**: 2026-04-15T05:55:02Z
+**User Input**: "ok, plan looks good"
+**AI Response**: "Prepared and presented the standardized Code Generation completion review gate for uow-cutover-hardening; awaiting explicit user choice to request changes or continue to Build and Test."
+**Context**: CONSTRUCTION - Code Generation approval gate
+
+---
+
+## Code Generation - Request Changes
+**Timestamp**: 2026-04-15T06:13:05Z
+**User Input**: "yes, lets improve this, we should generate on the fly (when does not exist) and persist in .soorma (where all other CLI generated artifacts live) and re-use that persisted value across different runs. also, I'm assuming, to rotate key developer will simply delete old key and soorma dev CLI will re-generate new key pair."
+**AI Response**: "Accepted the review-driven change request for uow-cutover-hardening and replaced the hardcoded dev private key in soorma dev with first-run RSA key generation persisted under .soorma/identity/, reuse across subsequent runs, explicit delete-to-rotate behavior, and updated SDK docs/changelog guidance."
+**Context**: CONSTRUCTION - Code Generation review correction
+
+---
+
+## Code Generation - Correction Review Prompt
+**Timestamp**: 2026-04-15T06:13:05Z
+**User Input**: "yes, lets improve this, we should generate on the fly (when does not exist) and persist in .soorma (where all other CLI generated artifacts live) and re-use that persisted value across different runs. also, I'm assuming, to rotate key developer will simply delete old key and soorma dev CLI will re-generate new key pair."
+**AI Response**: "Re-ran the focused CLI bootstrap regression after the correction pass, confirmed 29 passing tests, and prepared the renewed Code Generation review gate for uow-cutover-hardening."
+**Context**: CONSTRUCTION - Code Generation correction approval gate
 
 ---
 

--- a/aidlc-docs/platform/identity-service/construction/plans/uow-cutover-hardening-code-generation-plan.md
+++ b/aidlc-docs/platform/identity-service/construction/plans/uow-cutover-hardening-code-generation-plan.md
@@ -1,0 +1,201 @@
+# Code Generation Plan - uow-cutover-hardening
+
+## Unit Context
+- Unit: uow-cutover-hardening
+- Purpose: complete FR-11 phase 3 cutover by removing legacy tenant-header runtime dependence, enforcing JWT-only secured ingress behavior, converging active contracts on one canonical tenant identifier, finalizing RS256 and JWKS-only production trust paths, and closing the operational hardening gaps called out by the approved design.
+- Primary stories:
+  - US-4.3 Header Auth Removal Cutover (primary)
+  - US-3.1 Platform Principal JWT Issuance (hardening continuation)
+  - US-3.2 Delegated Context Claim Handling (finalization continuation)
+- Dependencies:
+  - Hard dependency: uow-shared-auth-foundation (approved/completed)
+  - Hard dependency: uow-identity-core-domain (approved/completed)
+  - Hard dependency: uow-sdk-jwt-integration (approved/completed)
+  - Downstream stage: Build and Test for the initiative
+- Test case traceability (QA construction enrichment + inception index):
+  - TC-UCH-001 JWT-only ingress after release cutover
+  - TC-UCH-002 Header-only request denied post-cutover
+  - TC-UCH-003 Structured telemetry emitted for denied legacy access
+  - TC-UCH-004 Trusted-caller self-issue succeeds with canonical tenant contract
+  - TC-UCH-005 Issue-for-other without override authority is denied
+  - TC-UCH-006 Legacy tenant alias payload is rejected
+  - TC-UCH-007 Unknown kid or invalid signature is denied fail-closed
+  - TC-UCH-008 Unallowlisted delegated issuer is denied before trust retrieval
+  - TC-UCH-009 Unknown kid denial emits alert-ready centralized signal
+
+## Architecture Pattern Alignment (docs/ARCHITECTURE_PATTERNS.md)
+- Section 1 Authentication and two-tier tenancy:
+  - secured service ingress must deny header-only requests after cutover and derive tenant and user context from bearer JWT claims only.
+  - trusted-caller token issuance remains the only deliberate secured exception and must enforce caller/subject and tenant-bound authorization server-side.
+- Section 2 Two-layer SDK architecture:
+  - handler-facing access remains through `context.memory`, `context.tracker`, `context.bus`, and `context.identity` wrappers only.
+  - any cutover transport changes stay inside low-level clients and wrapper internals; no direct service-client imports are introduced into agent code.
+- Section 3 Event choreography:
+  - event publishing and response semantics remain explicit; auth hardening must not alter `response_event` or correlation behavior.
+- Section 4 Multi-tenancy and RLS:
+  - canonical tenant identity must be server-derived and fail closed on mismatch, omission, or legacy alias drift.
+  - persistence and service contracts must converge on one active tenant identifier with explicit migration handling.
+- Section 5 State management:
+  - token issuance, override authorization, and key-rotation state remain explicit and auditable.
+- Section 6 Error handling:
+  - denial paths remain typed, safe, deterministic, and non-leaking.
+- Section 7 Testing:
+  - STUB -> RED -> GREEN -> REFACTOR remains mandatory, with explicit negative security coverage for cutover regressions.
+
+## Wrapper Completeness Verification (Section 2 Gate)
+- Existing handler-facing wrappers remain the required surface:
+  - `sdk/python/soorma/context.py`
+  - `sdk/python/soorma/identity/wrapper.py`
+- Unit 4 does not introduce new handler-visible service methods.
+- Verification focus for this unit:
+  - low-level clients stop depending on legacy tenant headers as the active auth path.
+  - wrapper signatures remain stable while forwarding canonical bearer-auth behavior internally.
+  - any identity-service caller-auth special cases stay isolated to `context.identity` and `soorma/identity/client.py` internals.
+
+## Expected Interfaces and Contracts
+- Shared auth contract:
+  - bearer JWT is required for all secured non-public routes except the approved token-issuance trusted-caller path.
+  - invalid JWT, unknown `kid`, unavailable trust source after cache expiry, and legacy alias mismatch all deny fail closed.
+- Canonical tenant contract:
+  - active runtime contracts use `tenant_id` as the canonical tenant identity.
+  - `platform_tenant_id` and `tenant_domain_id` are removed from active request/response and internal decision paths or are left only behind an explicit bounded migration/deprecation seam that does not remain part of the active contract.
+- Signing and verification contract:
+  - RS256 with identity-service private-key custody is the normal production issuance path.
+  - public-key verification uses JWKS/discovery or approved public-key distribution only.
+  - HS256 is not a normal production or default local-dev cutover path.
+- Delegated issuer contract:
+  - delegated trust validation uses approved OIDC/JWKS-backed issuer validation within bounded scope.
+  - unallowlisted issuers and policy-disallowed delegated claims are denied before deeper processing.
+- Telemetry contract:
+  - denied legacy/header-only access, override decisions, unknown `kid`, signature failures, and delegated-trust denials emit structured, token-safe telemetry.
+
+## Database Entities and Migration Scope
+- Existing identity-service persistence currently still uses `platform_tenant_identity_domains` and `tenant_domain_id`-based relationships.
+- Unit 4 must execute one of the approved bounded persistence outcomes:
+  - implement the schema/data migration needed to converge active contracts on canonical `tenant_id`, or
+  - preserve storage compatibility temporarily but remove `tenant_domain_id` from active API/runtime contracts with an explicit, documented bounded deprecation seam and migration note.
+- Any schema change must be explicit and migration-backed under `services/identity-service/alembic/versions/`.
+
+## Brownfield Code Targets (Exact Paths)
+
+### Shared Verification and Request Context (modify in place)
+- libs/soorma-service-common/src/soorma_service_common/middleware.py
+- libs/soorma-service-common/src/soorma_service_common/dependencies.py
+- libs/soorma-service-common/src/soorma_service_common/tenant_context.py
+
+### SDK Runtime and Low-Level Clients (modify in place)
+- sdk/python/soorma/context.py
+- sdk/python/soorma/memory/client.py
+- sdk/python/soorma/tracker/client.py
+- sdk/python/soorma/identity/client.py
+- sdk/python/soorma/events.py
+- sdk/python/soorma/cli/commands/dev.py
+
+### Identity Service Runtime and Policy Surfaces (modify in place)
+- services/identity-service/src/identity_service/core/config.py
+- services/identity-service/src/identity_service/core/dependencies.py
+- services/identity-service/src/identity_service/api/v1/tokens.py
+- services/identity-service/src/identity_service/api/v1/delegated_issuers.py
+- services/identity-service/src/identity_service/api/v1/discovery.py
+- services/identity-service/src/identity_service/services/token_service.py
+- services/identity-service/src/identity_service/services/provider_facade.py
+- services/identity-service/src/identity_service/services/delegated_trust_service.py
+- services/identity-service/src/identity_service/models/domain.py
+- services/identity-service/src/identity_service/crud/tenant_domains.py
+- services/identity-service/src/identity_service/crud/principals.py
+- services/identity-service/alembic/versions/0001_identity_core_init.py
+- services/identity-service/alembic/versions/ (new migration only if required)
+
+### Tests (modify/add)
+- libs/soorma-service-common/tests/test_middleware.py
+- libs/soorma-service-common/tests/test_dependencies.py
+- libs/soorma-service-common/tests/test_tenant_context.py
+- sdk/python/tests/test_memory_client.py
+- sdk/python/tests/test_tracker_service_client.py
+- sdk/python/tests/test_context_wrappers.py
+- sdk/python/tests/test_context_identity_wrapper.py
+- sdk/python/tests/cli/test_dev.py
+- services/identity-service/tests/test_token_api.py
+- services/identity-service/tests/test_provider_facade.py
+- services/identity-service/tests/test_delegated_issuer_api.py
+- services/identity-service/tests/test_discovery_api.py
+- services/identity-service/tests/test_onboarding_api.py
+
+### Documentation and Changelog Targets
+- services/identity-service/README.md
+- services/identity-service/CHANGELOG.md
+- sdk/python/CHANGELOG.md
+- docs/identity_service/README.md
+- docs/identity_service/JWT_TECHNICAL_ARCHITECTURE.md
+- docs/identity_service/ASYMMETRIC_BOOTSTRAP_PRIMER.md
+
+### Unit Documentation Output (Construction)
+- aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
+
+## Execution Checklist (Single Source of Truth)
+- [x] Step 1 - Analyze approved unit design artifacts, migration checklist, story map, test-case traceability, and dependency readiness.
+- [x] Step 2 - Validate architecture alignment (Sections 1-7) and wrapper completeness constraints.
+- [x] Step 3 - Confirm brownfield target paths and ownership boundaries (application code vs initiative documentation).
+- [x] Step 4 - Define implementation slices with STUB -> RED -> GREEN -> REFACTOR and explicit negative security coverage.
+- [x] Step 5 - Create this code-generation plan artifact for Unit 4.
+- [x] Step 6 - Log code-generation approval prompt in audit.md and request explicit plan approval.
+- [ ] Step 7 - Wait for explicit user approval of this plan before executing Part 2.
+- [ ] Step 8 - STUB phase (complete when 8A, 8B, 8C, and 8D are checked).
+- [ ] Step 8A - STUB (shared auth): introduce/adjust seams for JWT-only enforcement, canonical tenant extraction, and legacy denial reason codes.
+- [ ] Step 8B - STUB (SDK): prepare memory/tracker/event/identity client seams for JWT-only active behavior and header-path removal where required.
+- [ ] Step 8C - STUB (identity-service): prepare issuance authorization, delegated-trust finalization, and canonical tenant-contract migration seams.
+- [ ] Step 8D - STUB (docs/migration): prepare migration/doc update surfaces and summary artifact skeleton.
+- [ ] Step 9 - RED phase (complete when 9A, 9B, 9C, and 9D are checked).
+- [ ] Step 9A - RED (shared auth): failing tests for header-only denial, unknown `kid` deny, cache-expiry fail-closed behavior, and canonical tenant extraction.
+- [ ] Step 9B - RED (SDK): failing tests showing legacy header dependence is removed from active request behavior and JWT-only auth is projected correctly.
+- [ ] Step 9C - RED (identity-service): failing tests for self-issue-only baseline, override denial without authority, cross-tenant denial, delegated issuer allowlist/OIDC enforcement, and RS256-only production path.
+- [ ] Step 9D - RED (migration/docs): failing assertions or checks for canonical tenant naming, bootstrap defaults, and documented rollback/cutover expectations.
+- [ ] Step 10 - GREEN phase (complete when 10A, 10B, 10C, and 10D are checked).
+- [ ] Step 10A - GREEN (shared auth): implement JWT-only secured ingress behavior, typed deny reasons, and canonical tenant/user resolution.
+- [ ] Step 10B - GREEN (SDK): implement JWT-only active service-client behavior and align local bootstrap defaults with the approved hard-cutover contract.
+- [ ] Step 10C - GREEN (identity-service): implement caller-auth hardening, canonical tenant convergence, delegated OIDC/JWKS validation finalization, and RS256/JWKS-only production trust path.
+- [ ] Step 10D - GREEN (migration/docs): implement any required schema/data migration and update code-stage summary/docs/changelogs.
+- [ ] Step 11 - REFACTOR phase (complete when 11A, 11B, 11C, and 11D are checked).
+- [ ] Step 11A - REFACTOR (shared auth): simplify middleware/dependency precedence and preserve fail-closed guarantees.
+- [ ] Step 11B - REFACTOR (SDK): remove redundant compatibility code and tighten auth-token propagation boundaries.
+- [ ] Step 11C - REFACTOR (identity-service): simplify issuance and delegated-trust decision paths without weakening policy enforcement.
+- [ ] Step 11D - REFACTOR (migration/docs): remove stale terminology, dead compatibility notes, and redundant config guidance.
+- [ ] Step 12 - Execute focused test suites (complete when 12A, 12B, 12C, and 12D are checked).
+- [ ] Step 12A - Tests (shared auth): middleware, dependencies, and tenant-context suites.
+- [ ] Step 12B - Tests (SDK): memory/tracker/context/CLI suites for outbound auth behavior.
+- [ ] Step 12C - Tests (identity-service): token, delegated issuer, discovery, provider facade, and onboarding suites.
+- [ ] Step 12D - Tests (cross-cutover checks): explicit negative security cases and any migration verification added for this unit.
+- [ ] Step 13 - Produce code-stage summary artifact at aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md.
+- [ ] Step 14 - Present Code Generation completion gate (Request Changes / Continue to Next Stage).
+- [ ] Step 15 - On approval, update aidlc-state.md and audit.md, then transition to Build and Test.
+
+## Detailed Generation Sequence
+1. Shared auth cutover:
+   - remove active legacy header fallback for secured non-public routes.
+   - enforce canonical JWT-derived tenant and user context with fail-closed mismatch handling.
+   - emit structured denial telemetry for header-only and verification-failure paths.
+2. Identity-service hardening:
+   - keep token issuance as the only trusted-caller secured exception.
+   - enforce self-issue baseline and explicit admin-override authorization checks.
+   - finalize delegated issuer OIDC/JWKS validation within approved scope.
+   - eliminate HS256 as the normal production path.
+3. SDK/runtime alignment:
+   - update low-level clients and wrappers so active runtime behavior no longer depends on tenant headers for the cutover paths in scope.
+   - keep wrapper signatures stable.
+   - align `soorma dev` defaults and generated environment with RS256/JWKS hard-cutover expectations.
+4. Canonical tenant naming and migration:
+   - converge active code/docs/contracts on canonical `tenant_id` naming.
+   - implement or document bounded persistence migration/deprecation behavior explicitly.
+5. Focused regression and negative security coverage:
+   - header-only denial
+   - override denial without authority
+   - cross-tenant and cross-principal issuance denial
+   - invalid signature and unknown `kid` denial
+   - delegated issuer allowlist/trust-source denial
+6. Documentation and summary:
+   - update operational docs, changelogs, and the Unit 4 construction code summary.
+
+## Non-Applicable Items in This Unit
+- Frontend components and UI tests: N/A.
+- New standalone service creation: N/A (brownfield in-place hardening and migration only).
+- New handler-facing wrapper surface area: N/A unless implementation reveals an unavoidable gap, in which case wrapper completeness must be re-verified before execution proceeds.

--- a/aidlc-docs/platform/identity-service/construction/plans/uow-cutover-hardening-code-generation-plan.md
+++ b/aidlc-docs/platform/identity-service/construction/plans/uow-cutover-hardening-code-generation-plan.md
@@ -139,34 +139,34 @@
 - [x] Step 4 - Define implementation slices with STUB -> RED -> GREEN -> REFACTOR and explicit negative security coverage.
 - [x] Step 5 - Create this code-generation plan artifact for Unit 4.
 - [x] Step 6 - Log code-generation approval prompt in audit.md and request explicit plan approval.
-- [ ] Step 7 - Wait for explicit user approval of this plan before executing Part 2.
-- [ ] Step 8 - STUB phase (complete when 8A, 8B, 8C, and 8D are checked).
-- [ ] Step 8A - STUB (shared auth): introduce/adjust seams for JWT-only enforcement, canonical tenant extraction, and legacy denial reason codes.
-- [ ] Step 8B - STUB (SDK): prepare memory/tracker/event/identity client seams for JWT-only active behavior and header-path removal where required.
-- [ ] Step 8C - STUB (identity-service): prepare issuance authorization, delegated-trust finalization, and canonical tenant-contract migration seams.
-- [ ] Step 8D - STUB (docs/migration): prepare migration/doc update surfaces and summary artifact skeleton.
-- [ ] Step 9 - RED phase (complete when 9A, 9B, 9C, and 9D are checked).
-- [ ] Step 9A - RED (shared auth): failing tests for header-only denial, unknown `kid` deny, cache-expiry fail-closed behavior, and canonical tenant extraction.
-- [ ] Step 9B - RED (SDK): failing tests showing legacy header dependence is removed from active request behavior and JWT-only auth is projected correctly.
-- [ ] Step 9C - RED (identity-service): failing tests for self-issue-only baseline, override denial without authority, cross-tenant denial, delegated issuer allowlist/OIDC enforcement, and RS256-only production path.
-- [ ] Step 9D - RED (migration/docs): failing assertions or checks for canonical tenant naming, bootstrap defaults, and documented rollback/cutover expectations.
-- [ ] Step 10 - GREEN phase (complete when 10A, 10B, 10C, and 10D are checked).
-- [ ] Step 10A - GREEN (shared auth): implement JWT-only secured ingress behavior, typed deny reasons, and canonical tenant/user resolution.
-- [ ] Step 10B - GREEN (SDK): implement JWT-only active service-client behavior and align local bootstrap defaults with the approved hard-cutover contract.
-- [ ] Step 10C - GREEN (identity-service): implement caller-auth hardening, canonical tenant convergence, delegated OIDC/JWKS validation finalization, and RS256/JWKS-only production trust path.
-- [ ] Step 10D - GREEN (migration/docs): implement any required schema/data migration and update code-stage summary/docs/changelogs.
-- [ ] Step 11 - REFACTOR phase (complete when 11A, 11B, 11C, and 11D are checked).
-- [ ] Step 11A - REFACTOR (shared auth): simplify middleware/dependency precedence and preserve fail-closed guarantees.
-- [ ] Step 11B - REFACTOR (SDK): remove redundant compatibility code and tighten auth-token propagation boundaries.
-- [ ] Step 11C - REFACTOR (identity-service): simplify issuance and delegated-trust decision paths without weakening policy enforcement.
-- [ ] Step 11D - REFACTOR (migration/docs): remove stale terminology, dead compatibility notes, and redundant config guidance.
-- [ ] Step 12 - Execute focused test suites (complete when 12A, 12B, 12C, and 12D are checked).
-- [ ] Step 12A - Tests (shared auth): middleware, dependencies, and tenant-context suites.
-- [ ] Step 12B - Tests (SDK): memory/tracker/context/CLI suites for outbound auth behavior.
-- [ ] Step 12C - Tests (identity-service): token, delegated issuer, discovery, provider facade, and onboarding suites.
-- [ ] Step 12D - Tests (cross-cutover checks): explicit negative security cases and any migration verification added for this unit.
-- [ ] Step 13 - Produce code-stage summary artifact at aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md.
-- [ ] Step 14 - Present Code Generation completion gate (Request Changes / Continue to Next Stage).
+- [x] Step 7 - Wait for explicit user approval of this plan before executing Part 2.
+- [x] Step 8 - STUB phase (complete when 8A, 8B, 8C, and 8D are checked).
+- [x] Step 8A - STUB (shared auth): introduce/adjust seams for JWT-only enforcement, canonical tenant extraction, and legacy denial reason codes.
+- [x] Step 8B - STUB (SDK): prepare memory/tracker/event/identity client seams for JWT-only active behavior and header-path removal where required.
+- [x] Step 8C - STUB (identity-service): prepare issuance authorization, delegated-trust finalization, and canonical tenant-contract migration seams.
+- [x] Step 8D - STUB (docs/migration): prepare migration/doc update surfaces and summary artifact skeleton.
+- [x] Step 9 - RED phase (complete when 9A, 9B, 9C, and 9D are checked).
+- [x] Step 9A - RED (shared auth): failing tests for header-only denial, unknown `kid` deny, cache-expiry fail-closed behavior, and canonical tenant extraction.
+- [x] Step 9B - RED (SDK): failing tests showing legacy header dependence is removed from active request behavior and JWT-only auth is projected correctly.
+- [x] Step 9C - RED (identity-service): failing tests for self-issue-only baseline, override denial without authority, cross-tenant denial, delegated issuer allowlist/OIDC enforcement, and RS256-only production path.
+- [x] Step 9D - RED (migration/docs): failing assertions or checks for canonical tenant naming, bootstrap defaults, and documented rollback/cutover expectations.
+- [x] Step 10 - GREEN phase (complete when 10A, 10B, 10C, and 10D are checked).
+- [x] Step 10A - GREEN (shared auth): implement JWT-only secured ingress behavior, typed deny reasons, and canonical tenant/user resolution.
+- [x] Step 10B - GREEN (SDK): implement JWT-only active service-client behavior and align local bootstrap defaults with the approved hard-cutover contract.
+- [x] Step 10C - GREEN (identity-service): implement caller-auth hardening, canonical tenant convergence, delegated OIDC/JWKS validation finalization, and RS256/JWKS-only production trust path.
+- [x] Step 10D - GREEN (migration/docs): implement any required schema/data migration and update code-stage summary/docs/changelogs.
+- [x] Step 11 - REFACTOR phase (complete when 11A, 11B, 11C, and 11D are checked).
+- [x] Step 11A - REFACTOR (shared auth): simplify middleware/dependency precedence and preserve fail-closed guarantees.
+- [x] Step 11B - REFACTOR (SDK): remove redundant compatibility code and tighten auth-token propagation boundaries.
+- [x] Step 11C - REFACTOR (identity-service): simplify issuance and delegated-trust decision paths without weakening policy enforcement.
+- [x] Step 11D - REFACTOR (migration/docs): remove stale terminology, dead compatibility notes, and redundant config guidance.
+- [x] Step 12 - Execute focused test suites (complete when 12A, 12B, 12C, and 12D are checked).
+- [x] Step 12A - Tests (shared auth): middleware, dependencies, and tenant-context suites.
+- [x] Step 12B - Tests (SDK): memory/tracker/context/CLI suites for outbound auth behavior.
+- [x] Step 12C - Tests (identity-service): token, delegated issuer, discovery, provider facade, and onboarding suites.
+- [x] Step 12D - Tests (cross-cutover checks): explicit negative security cases and any migration verification added for this unit.
+- [x] Step 13 - Produce code-stage summary artifact at aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md.
+- [x] Step 14 - Present Code Generation completion gate (Request Changes / Continue to Next Stage).
 - [ ] Step 15 - On approval, update aidlc-state.md and audit.md, then transition to Build and Test.
 
 ## Detailed Generation Sequence

--- a/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
+++ b/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
@@ -3,21 +3,35 @@
 ## Scope Completed
 - Hardened shared tenancy middleware so secured non-public routes require bearer JWTs, preserve the trusted admin-key exception for identity control-plane paths, and prefer canonical `tenant_id` claims over compatibility aliases.
 - Updated low-level SDK Memory and Tracker clients so the active bearer-auth path sends `Authorization` without legacy `X-*` identity headers.
+- Extended SDK auth, event, registry, platform-context, and base-agent wiring so infrastructure traffic can carry bearer JWTs through the same wrapper/client surfaces used by agents and examples, including async token-provider/factory support for requesting, caching, and refreshing JWTs.
 - Added canonical `tenant_id` issuance in identity-service tokens while preserving compatibility claims for bounded migration.
 - Switched `soorma dev` local bootstrap from HS256-secret defaults to persisted `.soorma/identity/` RSA key material with inline JWKS/public-key verifier material derived from those files.
+- Added a shared example auth helper and persisted local JWT bootstrap flow so `examples/01-hello-world` can onboard once, reuse stored principal metadata, expose a reusable trusted-proxy style token provider, and inject bearer tokens into infrastructure-facing clients without per-example bootstrap shims.
 
 ## Brownfield Files Changed
 - `libs/soorma-service-common/src/soorma_service_common/middleware.py`
 - `sdk/python/soorma/memory/client.py`
 - `sdk/python/soorma/tracker/client.py`
+- `sdk/python/soorma/events.py`
+- `sdk/python/soorma/registry/client.py`
+- `sdk/python/soorma/auth.py`
+- `sdk/python/soorma/context.py`
+- `sdk/python/soorma/agents/base.py`
 - `sdk/python/soorma/cli/commands/dev.py`
 - `services/identity-service/src/identity_service/services/token_service.py`
+- `examples/01-hello-world/client.py`
+- `examples/01-hello-world/worker.py`
+- `examples/01-hello-world/start.sh`
+- `examples/01-hello-world/README.md`
+- `examples/shared/__init__.py`
+- `examples/shared/auth.py`
 - Focused tests under `libs/soorma-service-common/tests/`, `sdk/python/tests/`, and `services/identity-service/tests/`
 - Documentation and changelogs under `services/identity-service/`, `sdk/python/`, and `docs/identity_service/`
 
 ## Architecture Alignment
 - Section 1 Authentication and tenancy: secured ingress now denies header-only requests after cutover, while the explicit trusted admin-key exception remains bounded to identity control-plane routes.
-- Section 2 Two-layer SDK: handler-facing wrapper surfaces were unchanged; bearer-auth transport changes remain inside low-level clients and CLI bootstrap.
+- Section 2 Two-layer SDK: handler-facing wrapper surfaces were unchanged; bearer-auth transport changes remain inside low-level clients, context wiring, and CLI/example bootstrap helpers rather than leaking service-client details into handlers.
+- Section 3 Event choreography: event publish and stream registration semantics remain explicit while authorization moves into transport headers for event-service access.
 - Section 4 Multi-tenancy: active runtime extraction now prefers canonical `tenant_id` while keeping compatibility claims bounded to migration seams.
 - Section 6 Error handling: deny behavior remains fail closed for missing bearer tokens, invalid signatures, and unknown-key conditions.
 
@@ -27,6 +41,11 @@
 - `sdk/python/tests/test_tracker_service_client.py`
 - `sdk/python/tests/test_context_wrappers.py`
 - `sdk/python/tests/test_context_identity_wrapper.py`
+- `sdk/python/tests/test_bus_client.py`
+- `sdk/python/tests/test_event_client_registration.py`
+- `sdk/python/tests/test_registry_service_client.py`
+- `sdk/python/tests/test_example_auth_bootstrap.py`
+- `sdk/python/tests/test_agents.py`
 - `libs/soorma-service-common/tests/test_middleware.py`
 - `services/identity-service/tests/test_token_api.py`
 - `services/identity-service/tests/test_provider_facade.py`
@@ -42,8 +61,14 @@
 - Onboarding API suite: 4 passed
 - Wrapper suites: 25 passed
 - CLI correction pass after review feedback: 29 passed
+- Example/JWT propagation correction pass: 40 passed
+- Bearer-token provider correction pass: 83 SDK/example tests passed and 30 shared middleware tests passed
+- Shared-helper shim-removal cleanup: 51 focused SDK/example tests passed
 
 ## Residual Notes
 - Identity-service persistence still retains compatibility-era naming in storage tables; this unit keeps that behind a bounded migration seam while moving active issuance/verification behavior toward canonical `tenant_id`.
 - Monorepo pytest invocations still need package-local grouping because multiple `tests/conftest.py` files collide when mixed in one command.
 - Local key rotation now follows the documented delete-and-regenerate path: remove `.soorma/identity/` files and rerun `soorma dev`.
+- The hello-world example now depends on locally bootstrapped identity-service availability so it can reuse persisted onboarding metadata and let the shared token provider mint and cache JWTs before connecting to event or registry infrastructure.
+- Hello-world now imports the shared helper directly and no longer carries a local `auth_bootstrap.py` adapter; the shared module also exposes the CLI priming path used by `start.sh`.
+- Shared middleware now derives service identity from canonical JWT claims (`tenant_id`, `principal_id`, `sub`) when explicit service-claim aliases are absent, preserving bearer-only Tier-2 access after cutover.

--- a/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
+++ b/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
@@ -6,7 +6,9 @@
 - Extended SDK auth, event, registry, platform-context, and base-agent wiring so infrastructure traffic can carry bearer JWTs through the same wrapper/client surfaces used by agents and examples, including async token-provider/factory support for requesting, caching, and refreshing JWTs.
 - Added canonical `tenant_id` issuance in identity-service tokens while preserving compatibility claims for bounded migration.
 - Switched `soorma dev` local bootstrap from HS256-secret defaults to persisted `.soorma/identity/` RSA key material with inline JWKS/public-key verifier material derived from those files.
-- Added a shared example auth helper and persisted local JWT bootstrap flow so `examples/01-hello-world` can onboard once, reuse stored principal metadata, expose a reusable trusted-proxy style token provider, and inject bearer tokens into infrastructure-facing clients without per-example bootstrap shims.
+- Added a shared example auth helper and persisted local JWT bootstrap flow so `examples/01-hello-world` can onboard once, reuse stored principal metadata, expose a reusable trusted-proxy style token provider, surface the bootstrapped platform tenant and admin principal identifiers, and inject bearer tokens into infrastructure-facing clients without per-example bootstrap shims or hard-coded tenant IDs.
+- Updated identity-service low-level client binding so platform tenant context is supplied only after onboarding/discovery instead of being assumed at construction time.
+- Removed low-level identity-client symmetric caller-JWT generation so identity-admin requests now use only the admin API key plus optional bound `X-Tenant-ID` until a future explicit caller-principal injection path is designed.
 
 ## Brownfield Files Changed
 - `libs/soorma-service-common/src/soorma_service_common/middleware.py`
@@ -44,6 +46,7 @@
 - `sdk/python/tests/test_bus_client.py`
 - `sdk/python/tests/test_event_client_registration.py`
 - `sdk/python/tests/test_registry_service_client.py`
+- `sdk/python/tests/test_identity_service_client.py`
 - `sdk/python/tests/test_example_auth_bootstrap.py`
 - `sdk/python/tests/test_agents.py`
 - `libs/soorma-service-common/tests/test_middleware.py`
@@ -64,6 +67,8 @@
 - Example/JWT propagation correction pass: 40 passed
 - Bearer-token provider correction pass: 83 SDK/example tests passed and 30 shared middleware tests passed
 - Shared-helper shim-removal cleanup: 51 focused SDK/example tests passed
+- Bootstrap-derived platform-tenant correction pass: 28 focused SDK/example tests passed
+- Identity-client transport cleanup after review feedback: 27 focused SDK/example tests passed
 
 ## Residual Notes
 - Identity-service persistence still retains compatibility-era naming in storage tables; this unit keeps that behind a bounded migration seam while moving active issuance/verification behavior toward canonical `tenant_id`.
@@ -71,4 +76,7 @@
 - Local key rotation now follows the documented delete-and-regenerate path: remove `.soorma/identity/` files and rerun `soorma dev`.
 - The hello-world example now depends on locally bootstrapped identity-service availability so it can reuse persisted onboarding metadata and let the shared token provider mint and cache JWTs before connecting to event or registry infrastructure.
 - Hello-world now imports the shared helper directly and no longer carries a local `auth_bootstrap.py` adapter; the shared module also exposes the CLI priming path used by `start.sh`.
+- Hello-world now derives both tenant and bootstrap-admin identifiers from the persisted bootstrap payload instead of embedding platform tenant constants in the example client.
+- Low-level identity client requests no longer assume a platform tenant exists before onboarding; callers may bind it after bootstrap or pass it explicitly per request.
+- Low-level identity client no longer self-mints caller JWTs from local symmetric secrets; current transport is admin API key only before bootstrap and admin API key plus bound `X-Tenant-ID` after bootstrap.
 - Shared middleware now derives service identity from canonical JWT claims (`tenant_id`, `principal_id`, `sub`) when explicit service-claim aliases are absent, preserving bearer-only Tier-2 access after cutover.

--- a/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
+++ b/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
@@ -7,6 +7,7 @@
 - Added canonical `tenant_id` issuance in identity-service tokens while preserving compatibility claims for bounded migration.
 - Switched `soorma dev` local bootstrap from HS256-secret defaults to persisted `.soorma/identity/` RSA key material with inline JWKS/public-key verifier material derived from those files.
 - Added a shared example auth helper and persisted local JWT bootstrap flow so `examples/01-hello-world` can onboard once, reuse stored principal metadata, expose a reusable trusted-proxy style token provider, surface the bootstrapped platform tenant and admin principal identifiers, and inject bearer tokens into infrastructure-facing clients without per-example bootstrap shims or hard-coded tenant IDs.
+- Applied the same shared example auth-provider pattern to `examples/01-hello-tool`, including startup bootstrap priming, client-side bearer-token injection, and tool initialization with the shared provider.
 - Updated identity-service low-level client binding so platform tenant context is supplied only after onboarding/discovery instead of being assumed at construction time.
 - Removed low-level identity-client symmetric caller-JWT generation so identity-admin requests now use only the admin API key plus optional bound `X-Tenant-ID` until a future explicit caller-principal injection path is designed.
 
@@ -25,6 +26,10 @@
 - `examples/01-hello-world/worker.py`
 - `examples/01-hello-world/start.sh`
 - `examples/01-hello-world/README.md`
+- `examples/01-hello-tool/client.py`
+- `examples/01-hello-tool/calculator_tool.py`
+- `examples/01-hello-tool/start.sh`
+- `examples/01-hello-tool/README.md`
 - `examples/shared/__init__.py`
 - `examples/shared/auth.py`
 - Focused tests under `libs/soorma-service-common/tests/`, `sdk/python/tests/`, and `services/identity-service/tests/`
@@ -75,6 +80,7 @@
 - Monorepo pytest invocations still need package-local grouping because multiple `tests/conftest.py` files collide when mixed in one command.
 - Local key rotation now follows the documented delete-and-regenerate path: remove `.soorma/identity/` files and rerun `soorma dev`.
 - The hello-world example now depends on locally bootstrapped identity-service availability so it can reuse persisted onboarding metadata and let the shared token provider mint and cache JWTs before connecting to event or registry infrastructure.
+- The hello-tool example now follows the same bootstrap-and-provider path as hello-world, instead of relying on hard-coded tenant/user constants for Event Service access.
 - Hello-world now imports the shared helper directly and no longer carries a local `auth_bootstrap.py` adapter; the shared module also exposes the CLI priming path used by `start.sh`.
 - Hello-world now derives both tenant and bootstrap-admin identifiers from the persisted bootstrap payload instead of embedding platform tenant constants in the example client.
 - Low-level identity client requests no longer assume a platform tenant exists before onboarding; callers may bind it after bootstrap or pass it explicitly per request.

--- a/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
+++ b/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
@@ -1,0 +1,49 @@
+# Code Generation Summary - uow-cutover-hardening
+
+## Scope Completed
+- Hardened shared tenancy middleware so secured non-public routes require bearer JWTs, preserve the trusted admin-key exception for identity control-plane paths, and prefer canonical `tenant_id` claims over compatibility aliases.
+- Updated low-level SDK Memory and Tracker clients so the active bearer-auth path sends `Authorization` without legacy `X-*` identity headers.
+- Added canonical `tenant_id` issuance in identity-service tokens while preserving compatibility claims for bounded migration.
+- Switched `soorma dev` local bootstrap from HS256-secret defaults to persisted `.soorma/identity/` RSA key material with inline JWKS/public-key verifier material derived from those files.
+
+## Brownfield Files Changed
+- `libs/soorma-service-common/src/soorma_service_common/middleware.py`
+- `sdk/python/soorma/memory/client.py`
+- `sdk/python/soorma/tracker/client.py`
+- `sdk/python/soorma/cli/commands/dev.py`
+- `services/identity-service/src/identity_service/services/token_service.py`
+- Focused tests under `libs/soorma-service-common/tests/`, `sdk/python/tests/`, and `services/identity-service/tests/`
+- Documentation and changelogs under `services/identity-service/`, `sdk/python/`, and `docs/identity_service/`
+
+## Architecture Alignment
+- Section 1 Authentication and tenancy: secured ingress now denies header-only requests after cutover, while the explicit trusted admin-key exception remains bounded to identity control-plane routes.
+- Section 2 Two-layer SDK: handler-facing wrapper surfaces were unchanged; bearer-auth transport changes remain inside low-level clients and CLI bootstrap.
+- Section 4 Multi-tenancy: active runtime extraction now prefers canonical `tenant_id` while keeping compatibility claims bounded to migration seams.
+- Section 6 Error handling: deny behavior remains fail closed for missing bearer tokens, invalid signatures, and unknown-key conditions.
+
+## Verification Executed
+- `sdk/python/tests/cli/test_dev.py`
+- `sdk/python/tests/test_memory_client.py`
+- `sdk/python/tests/test_tracker_service_client.py`
+- `sdk/python/tests/test_context_wrappers.py`
+- `sdk/python/tests/test_context_identity_wrapper.py`
+- `libs/soorma-service-common/tests/test_middleware.py`
+- `services/identity-service/tests/test_token_api.py`
+- `services/identity-service/tests/test_provider_facade.py`
+- `services/identity-service/tests/test_delegated_issuer_api.py`
+- `services/identity-service/tests/test_discovery_api.py`
+
+## Results
+- SDK CLI + client suites: 58 passed
+- Shared middleware suite: 29 passed
+- Identity token API suite: 7 passed
+- Provider facade suite: 6 passed
+- Delegated issuer + discovery suites: 5 passed
+- Onboarding API suite: 4 passed
+- Wrapper suites: 25 passed
+- CLI correction pass after review feedback: 29 passed
+
+## Residual Notes
+- Identity-service persistence still retains compatibility-era naming in storage tables; this unit keeps that behind a bounded migration seam while moving active issuance/verification behavior toward canonical `tenant_id`.
+- Monorepo pytest invocations still need package-local grouping because multiple `tests/conftest.py` files collide when mixed in one command.
+- Local key rotation now follows the documented delete-and-regenerate path: remove `.soorma/identity/` files and rerun `soorma dev`.

--- a/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
+++ b/aidlc-docs/platform/identity-service/construction/uow-cutover-hardening/code/code-generation-summary.md
@@ -8,6 +8,7 @@
 - Switched `soorma dev` local bootstrap from HS256-secret defaults to persisted `.soorma/identity/` RSA key material with inline JWKS/public-key verifier material derived from those files.
 - Added a shared example auth helper and persisted local JWT bootstrap flow so `examples/01-hello-world` can onboard once, reuse stored principal metadata, expose a reusable trusted-proxy style token provider, surface the bootstrapped platform tenant and admin principal identifiers, and inject bearer tokens into infrastructure-facing clients without per-example bootstrap shims or hard-coded tenant IDs.
 - Applied the same shared example auth-provider pattern to `examples/01-hello-tool`, including startup bootstrap priming, client-side bearer-token injection, and tool initialization with the shared provider.
+- Applied the shared example auth-provider pattern across the remaining example suite so each example `start.sh` primes bootstrap state, each internal event-bus client publishes with bootstrap-derived tenant and principal identifiers, and each worker/planner/tool or direct service client uses the shared provider instead of static platform-tenant assumptions.
 - Updated identity-service low-level client binding so platform tenant context is supplied only after onboarding/discovery instead of being assumed at construction time.
 - Removed low-level identity-client symmetric caller-JWT generation so identity-admin requests now use only the admin API key plus optional bound `X-Tenant-ID` until a future explicit caller-principal injection path is designed.
 
@@ -30,6 +31,18 @@
 - `examples/01-hello-tool/calculator_tool.py`
 - `examples/01-hello-tool/start.sh`
 - `examples/01-hello-tool/README.md`
+- `examples/02-events-simple/*`
+- `examples/03-events-structured/*`
+- `examples/04-memory-working/*`
+- `examples/05-memory-semantic/*`
+- `examples/06-memory-episodic/*`
+- `examples/08-worker-basic/*`
+- `examples/09-planner-basic/*`
+- `examples/10-choreography-basic/*`
+- `examples/11-discovery-llm/*`
+- `examples/12-event-selector/*`
+- `examples/13-a2a-gateway/*`
+- `examples/research-advisor/*`
 - `examples/shared/__init__.py`
 - `examples/shared/auth.py`
 - Focused tests under `libs/soorma-service-common/tests/`, `sdk/python/tests/`, and `services/identity-service/tests/`
@@ -59,6 +72,7 @@
 - `services/identity-service/tests/test_provider_facade.py`
 - `services/identity-service/tests/test_delegated_issuer_api.py`
 - `services/identity-service/tests/test_discovery_api.py`
+- `python -m py_compile` on the newly migrated `research-advisor` and `13-a2a-gateway` Python files
 
 ## Results
 - SDK CLI + client suites: 58 passed
@@ -74,6 +88,7 @@
 - Shared-helper shim-removal cleanup: 51 focused SDK/example tests passed
 - Bootstrap-derived platform-tenant correction pass: 28 focused SDK/example tests passed
 - Identity-client transport cleanup after review feedback: 27 focused SDK/example tests passed
+- Final example migration syntax validation: `py_compile` passed for the remaining migrated `research-advisor` and `13-a2a-gateway` Python files
 
 ## Residual Notes
 - Identity-service persistence still retains compatibility-era naming in storage tables; this unit keeps that behind a bounded migration seam while moving active issuance/verification behavior toward canonical `tenant_id`.
@@ -81,6 +96,7 @@
 - Local key rotation now follows the documented delete-and-regenerate path: remove `.soorma/identity/` files and rerun `soorma dev`.
 - The hello-world example now depends on locally bootstrapped identity-service availability so it can reuse persisted onboarding metadata and let the shared token provider mint and cache JWTs before connecting to event or registry infrastructure.
 - The hello-tool example now follows the same bootstrap-and-provider path as hello-world, instead of relying on hard-coded tenant/user constants for Event Service access.
+- The full example suite now follows the same shared bootstrap/token-provider pattern for internal Soorma infrastructure access; the only intentional exception is the external plain-HTTP client in `examples/13-a2a-gateway/client.py`, which remains outside the internal event-bus auth flow.
 - Hello-world now imports the shared helper directly and no longer carries a local `auth_bootstrap.py` adapter; the shared module also exposes the CLI priming path used by `start.sh`.
 - Hello-world now derives both tenant and bootstrap-admin identifiers from the persisted bootstrap payload instead of embedding platform tenant constants in the example client.
 - Low-level identity client requests no longer assume a platform tenant exists before onboarding; callers may bind it after bootstrap or pass it explicitly per request.

--- a/docs/ARCHITECTURE_PATTERNS.md
+++ b/docs/ARCHITECTURE_PATTERNS.md
@@ -19,9 +19,9 @@ Soorma operates with **two distinct tenancy dimensions**. Understanding this dis
 - **Who:** Agent developers (companies/individuals) who build on the Soorma Core platform
 - **Purpose:** Isolates one developer's registered agents and event schemas from another developer's
 - **Scope:** **Registry Service only** — agents, events, and payload schemas belong to the developer tenant
-- **Identifier:** Developer Tenant UUID (`SOORMA_DEVELOPER_TENANT_ID` env var)
-- **Current header:** `X-Tenant-ID` (developer UUID) — **no `X-User-ID`**
-- **Future auth:** Developer API Key (v0.9.0+) — replaces the manual env-var header
+- **Identifier:** Platform-tenant identity carried in validated bearer-token claims
+- **Current auth:** `Authorization: Bearer <jwt>` for secured runtime traffic
+- **Future auth:** Selected control-plane routes may add API-key flows, but bearer-authenticated machine and developer principals remain the baseline runtime path
 - **Example:** Acme Corp's registered workers are invisible to Contoso's workers in the same Soorma deployment
 
 #### Tier 2: Client Tenant + User (Developer's Application Tenancy)
@@ -29,111 +29,103 @@ Soorma operates with **two distinct tenancy dimensions**. Understanding this dis
 - **Who:** End-users and customer tenants of the **developer's** agentic application
 - **Purpose:** Isolates one developer's customer's data from another customer's (memory, tasks, plans)
 - **Scope:** **Memory Service, Tracker Service, Event Service** — task contexts, plans, episodic memory
-- **Identifiers:** Client Tenant UUID + User UUID (carried in event envelope)
-- **Current headers:** `X-Tenant-ID` (platform tenant UUID) + `X-Service-Tenant-ID` (client tenant UUID) + `X-User-ID` (user UUID)
-- **Future auth:** JWT token issued by the developer's app — Soorma extracts `tenant_id` + `user_id` from claims
+- **Identifiers:** Platform tenant + client tenant + end-user identity carried in validated JWT claims
+- **Current auth:** `Authorization: Bearer <jwt>`
+- **Compatibility aliases:** `X-Service-Tenant-ID` and `X-User-ID` may appear on trusted internal calls, but they must match the JWT when present
+- **Future auth:** Same bearer-token model with progressively stricter issuer validation and delegated-trust controls
 - **Example:** Acme Corp's customer Alice's conversation history is isolated from customer Bob's
 
 #### Service → Tenancy Tier Mapping
 
-| Service | Tenancy Tier | Headers (Current) | Future Auth |
-|---------|-------------|-------------------|-------------|
-| **Registry Service** | Developer Tenant | `X-Tenant-ID` (developer UUID only) | Developer API Key |
-| **Memory Service** | Client Tenant + User | `X-Tenant-ID` (platform) + `X-Service-Tenant-ID` (client) + `X-User-ID` | JWT (client user token) |
-| **Tracker Service** | Client Tenant + User | `X-Tenant-ID` (platform) + `X-Service-Tenant-ID` (client) + `X-User-ID` | JWT (client user token) |
-| **Event Service** | Client Tenant + User | `X-Tenant-ID` (platform) + `X-Service-Tenant-ID` (client) + `X-User-ID` | JWT (client user token) |
+| Service | Tenancy Tier | Current Auth | Notes |
+|---------|-------------|--------------|-------|
+| **Registry Service** | Developer Tenant | Bearer JWT | Platform tenant and principal identity come from JWT claims |
+| **Memory Service** | Client Tenant + User | Bearer JWT | Service tenant and user come from JWT claims |
+| **Tracker Service** | Client Tenant + User | Bearer JWT | Service tenant and user come from JWT claims |
+| **Event Service** | Client Tenant + User | Bearer JWT | Platform tenant claim is authoritative at ingress |
 
-### Current Multi-Tenancy Header Split
+### Current Identity Projection Model
 
-For the current multi-tenancy rollout, SDK and service code must treat identity as a split between a platform tenant and service-scoped caller identity:
+For the current multi-tenancy rollout, SDK and service code must treat identity as validated bearer-token state projected into request context by shared middleware:
 
 | Concern | Current Source | Transport | Notes |
 |---------|----------------|-----------|-------|
-| Platform tenant | `DEFAULT_PLATFORM_TENANT_ID` / `SOORMA_PLATFORM_TENANT_ID` | `X-Tenant-ID` header | Fixed at low-level client construction time for Memory, Tracker, and Event publish paths |
-| Service tenant | Event envelope `tenant_id` or explicit wrapper arg | `X-Service-Tenant-ID` header | Passed per call; represents the developer application's customer tenant |
-| Service user | Event envelope `user_id` or explicit wrapper arg | `X-User-ID` header | Passed per call; represents the end user within the service tenant |
+| Platform tenant | JWT `platform_tenant_id` or `tenant_id` claim | `Authorization: Bearer ...` | Required on secured routes |
+| Service tenant | JWT `service_tenant_id` claim | `Authorization: Bearer ...` | Optional alias header cannot disagree with JWT |
+| Service user | JWT `service_user_id`, `user_id`, `principal_id`, or `sub` claim | `Authorization: Bearer ...` | Optional alias header cannot disagree with JWT |
 
 Current SDK rules:
 
-- `MemoryServiceClient` and `TrackerServiceClient` own the platform tenant and project all three headers on every request.
-- PlatformContext wrappers may default `tenant_id` and `user_id` from the bound event envelope, but explicit arguments always win.
-- `EventClient.publish()` must send `X-Tenant-ID` for the platform tenant while keeping `tenant_id` and `user_id` in the event envelope only.
-- SDK callers must not inject `platform_tenant_id` into outbound event payloads or envelopes. Event Service remains the trust boundary for any platform-tenant enrichment.
+- Low-level SDK clients accept auth explicitly via `auth_token` or `auth_token_provider`; they do not read bearer tokens from environment variables at runtime.
+- PlatformContext wrappers may still default service-tenant and user values from the bound event envelope, but outbound service authentication is bearer-token based.
+- `EventClient.publish()` must not inject `platform_tenant_id` into outbound event payloads. Event Service remains the trust boundary for platform-tenant enrichment.
+- Trusted admin flows are limited to explicit identity-service admin headers; normal service traffic must not fall back to legacy tenancy headers.
 
 ---
 
-### Current Pattern: Custom Headers (v0.7.x)
+### Current Pattern: Bearer Tokens (v0.8.x)
 
-**Status:** ⚠️ Development-only pattern - NOT for production use
+**Status:** Active runtime contract for secured service-to-service traffic
 
-SDK-to-service communication uses **custom HTTP headers** for authentication context. The specific headers differ by service tier (see table above):
+SDK-to-service communication uses **explicit bearer tokens**. Shared middleware validates the token and projects the resulting identity into `request.state`.
 
 **Tier 2 services (Memory, Tracker, Event):**
-- `X-Tenant-ID`: Platform tenant identifier (UUID)
-- `X-Service-Tenant-ID`: Client tenant identifier (UUID)
-- `X-User-ID`: End-user identifier (UUID)
+- `Authorization: Bearer <jwt>` is required
+- JWT claims carry platform tenant, service tenant, and service user identity
+- Optional compatibility headers must match the token when present
 
 **Tier 1 service (Registry):**
-- `X-Tenant-ID`: Developer tenant identifier (UUID) — no `X-User-ID`
+- `Authorization: Bearer <jwt>` is required
+- JWT claims carry the developer platform tenant and the authenticated machine or developer principal
 
 **Implementation (Tier 2 — Memory/Tracker/Event services):**
 
 ```python
-# SDK MemoryServiceClient example (platform tenant + service tenant + user headers)
+# SDK MemoryServiceClient example (explicit bearer auth)
 response = await self._client.post(
     f"{self.base_url}/v1/memory/task-context",
     json=data.model_dump(by_alias=True),
-    headers={
-        "X-Tenant-ID": platform_tenant_id,
-        "X-Service-Tenant-ID": client_tenant_id,
-        "X-User-ID": user_id,
-    },
+    headers={"Authorization": f"Bearer {token}"},
 )
 ```
 
 **Implementation (Tier 1 — Registry Service):**
 
 ```python
-# RegistryClient — developer tenant only, no X-User-ID
+# RegistryClient — explicit bearer auth, developer tenant from claims
 response = await self._client.post(
     f"{self.base_url}/v1/agents",
     json=request.model_dump(by_alias=True),
-    headers={
-        "X-Tenant-ID": developer_tenant_id,  # From SOORMA_DEVELOPER_TENANT_ID
-        # No X-User-ID — registry is scoped to the developer, not an end-user
-    },
+    headers={"Authorization": f"Bearer {token}"},
 )
 ```
 
 **Services Implementation:**
 
-Services extract these headers and use them for:
+Services extract validated request identity and use it for:
 - Row-Level Security (RLS) policies in PostgreSQL
 - Query filtering by tenant/user
 - Audit logging
 
 ```python
-# Memory/Tracker service endpoint example (Tier 2 — platform tenant + client tenant + user)
+# Memory/Tracker service endpoint example (Tier 2 — identity resolved by middleware)
 @router.post("/v1/memory/task-context")
 async def store_task_context(
     data: TaskContextCreate,
-    platform_tenant_id: str = Header(None, alias="X-Tenant-ID"),
-    tenant_id: str = Header(None, alias="X-Service-Tenant-ID"),
-    user_id: str = Header(None, alias="X-User-ID"),
+    ctx: TenantContext = Depends(get_tenant_context),
 ):
     # Set session variables for RLS
-    await db.execute(f"SET app.tenant_id = '{tenant_id}'")
-    await db.execute(f"SET app.user_id = '{user_id}'")
+    await db.execute(f"SET app.tenant_id = '{ctx.service_tenant_id}'")
+    await db.execute(f"SET app.user_id = '{ctx.service_user_id}'")
     result = await db.execute(...)
 
 # Registry service endpoint example (Tier 1 — developer tenant only)
 @router.post("/v1/agents")
 async def register_agent(
     data: AgentRegistrationRequest,
-    tenant_id: str = Header(None, alias="X-Tenant-ID"),  # developer tenant
-    # No X-User-ID header
+    platform_tenant_id: str = Depends(get_platform_tenant_id),
 ):
-    await db.execute(f"SET app.tenant_id = '{tenant_id}'")
+    await db.execute(f"SET app.tenant_id = '{platform_tenant_id}'")
     result = await db.execute(...)
 ```
 
@@ -155,13 +147,13 @@ CREATE POLICY agents_tenant_isolation ON agents
     USING (tenant_id = current_setting('app.tenant_id')::UUID);
 ```
 
-### Future Pattern: JWT & API Keys (v0.9.0+)
+### Future Pattern: Delegated JWT Trust & Selective API Keys (v0.9.0+)
 
-**Status:** 📋 Planned - Not yet implemented
+**Status:** 📋 Planned hardening and expansion work
 
 The production authentication system will support dual modes:
 
-**Mode 1: JWT Authentication (User Context)**
+**Mode 1: JWT Authentication (User and machine context)**
 ```python
 # User-facing applications
 context = PlatformContext(auth_token="jwt-token")
@@ -176,11 +168,11 @@ await context.memory.store_task_context(...)
 # }
 ```
 
-**Mode 2: API Key Authentication (Agent Context)**
+**Mode 2: API Key Authentication (Selected control-plane flows)**
 ```python
-# Agent-to-agent communication
-context = PlatformContext(api_key="agent-api-key-xyz")
-await context.memory.store_task_context(...)
+# Selected control-plane clients
+context = PlatformContext(api_key="control-plane-api-key")
+await context.registry.register_agent(...)
 
 # API Key metadata:
 # {
@@ -194,8 +186,8 @@ await context.memory.store_task_context(...)
 
 | Tier | Current (v0.8.x) | v0.9.0+ | v1.0.0 |
 |------|-----------------|---------|--------|
-| Developer Tenant (Registry) | `X-Tenant-ID` env var | Developer API Key | API Key only |
-| Client Tenant+User (Memory/Tracker/Event) | `X-Tenant-ID` + `X-Service-Tenant-ID` + `X-User-ID` headers | JWT token | JWT only |
+| Developer Tenant (Registry) | Bearer JWT | Bearer JWT + optional control-plane API key | Explicitly documented split by route class |
+| Client Tenant+User (Memory/Tracker/Event) | Bearer JWT | Bearer JWT with delegated trust | JWT only |
 
 ---
 
@@ -252,7 +244,7 @@ Soorma SDK follows a **strict two-layer abstraction** to separate low-level serv
 
 **Characteristics:**
 - Direct HTTP calls with `httpx`
-- Manual header injection (`X-Tenant-ID`, `X-Service-Tenant-ID`, `X-User-ID`)
+- Explicit bearer-auth header injection
 - Pydantic model serialization/deserialization
 - Fine-grained error handling
 - **NOT for agent handler use**

--- a/docs/identity_service/ASYMMETRIC_BOOTSTRAP_PRIMER.md
+++ b/docs/identity_service/ASYMMETRIC_BOOTSTRAP_PRIMER.md
@@ -1,26 +1,47 @@
 # Asymmetric JWT Bootstrap Primer (Local Soorma Stack)
 
 **Audience:** Developers running `soorma dev` locally
-**Scope:** Unit 3 compatibility phase (RS256 issuer + JWKS verification)
+**Scope:** Unit 4 cutover hardening (`soorma dev` RS256/JWKS bootstrap defaults)
 
 ## 1. Quick Answer
 
-Today, `soorma dev` does not auto-generate RSA keypairs for you.
+`soorma dev` now bootstraps a persisted local RS256 keypair and inline JWKS verifier config by default.
 
-It can bootstrap a deterministic local stack, but asymmetric mode still requires providing signing/verification material via environment variables.
+You only need manual overrides when you want to test alternate key material or simulate key rotation.
 
-This primer gives a copy-paste workflow so you can run RS256 + JWKS mode reliably.
+This primer explains the default behavior and the override path.
 
 ## 2. What You Will Configure
 
-You need four categories of settings:
+You need four categories of settings when overriding the defaults:
 
 1. Identity-service issuer signing settings (private/public key + active `kid`)
 2. Verifier settings for all services using `soorma-service-common` middleware
 3. Issuer trust and audience settings
 4. `soorma dev` bootstrap/restart workflow to avoid drift failures
 
-## 3. Generate Local RSA Keys
+## 3. Default `soorma dev` Behavior
+
+When you run `soorma dev --start`, the CLI creates `.soorma/identity/` on first use and persists:
+
+1. `.soorma/identity/identity-signing-private.pem`
+2. `.soorma/identity/identity-signing-public.pem`
+3. `.soorma/identity/identity-jwks.json`
+
+The generated `.soorma/.env` then includes:
+
+1. `IDENTITY_SIGNING_ALGORITHM=RS256`
+2. `IDENTITY_ACTIVE_SIGNING_KID=dev-rs256`
+3. `IDENTITY_SIGNING_PRIVATE_KEYRING_JSON` derived from the persisted private key
+4. `IDENTITY_SIGNING_PUBLIC_KEYRING_JSON` derived from the persisted public key
+5. Inline `IDENTITY_JWKS_PUBLICATION_JSON` and `SOORMA_AUTH_JWKS_JSON` derived from the persisted JWKS file
+6. Static `SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON` fallback derived from the persisted public key
+
+That means the local stack starts in RS256/JWKS mode without extra shell setup and reuses the same keypair across runs until you delete it.
+
+To rotate the local keypair, delete the files under `.soorma/identity/` and run `soorma dev` again.
+
+## 4. Generate Alternate Local RSA Keys
 
 Run from repository root (`soorma-core`):
 
@@ -38,48 +59,49 @@ openssl rsa \
   -out .soorma/keys/identity-signing-public.pem
 ```
 
-## 4. Convert PEMs to Environment-Safe Values
+## 5. Convert PEMs to Environment-Safe JSON Keyrings
 
-Docker compose `.env` values are single-line strings. Convert PEM files to escaped-newline strings:
+Docker compose `.env` values are single-line strings. Build JSON keyrings so PEM newlines survive parsing cleanly:
 
 ```bash
-escape_pem() {
-  awk 'NF {sub(/\r/, ""); printf "%s\\n", $0;}' "$1"
-}
+python - <<'PY'
+import json
+from pathlib import Path
 
-export IDENTITY_SIGNING_PRIVATE_KEY_PEM="$(escape_pem .soorma/keys/identity-signing-private.pem)"
-export IDENTITY_SIGNING_PUBLIC_KEY_PEM="$(escape_pem .soorma/keys/identity-signing-public.pem)"
+private_pem = Path('.soorma/keys/identity-signing-private.pem').read_text()
+public_pem = Path('.soorma/keys/identity-signing-public.pem').read_text()
+
+print('export IDENTITY_SIGNING_PRIVATE_KEYRING_JSON=' + json.dumps(json.dumps({'local-rs1': private_pem})))
+print('export IDENTITY_SIGNING_PUBLIC_KEYRING_JSON=' + json.dumps(json.dumps({'local-rs1': public_pem})))
+PY
 ```
 
-## 5. Set RS256/JWKS Environment Variables
+## 6. Set RS256/JWKS Override Variables
 
 Use this exact baseline before `soorma dev --start`:
 
 ```bash
 # Issuer signing mode
 export IDENTITY_SIGNING_ALGORITHM=RS256
-export IDENTITY_SIGNING_KEY_ID=local-rs1
 export IDENTITY_ACTIVE_SIGNING_KID=local-rs1
-export IDENTITY_SIGNING_PRIVATE_KEY_PEM="$IDENTITY_SIGNING_PRIVATE_KEY_PEM"
-export IDENTITY_SIGNING_PUBLIC_KEY_PEM="$IDENTITY_SIGNING_PUBLIC_KEY_PEM"
+export IDENTITY_SIGNING_PRIVATE_KEYRING_JSON="$IDENTITY_SIGNING_PRIVATE_KEYRING_JSON"
+export IDENTITY_SIGNING_PUBLIC_KEYRING_JSON="$IDENTITY_SIGNING_PUBLIC_KEYRING_JSON"
 
 # Keep issuer claim/trust aligned with current token issuance behavior
 export SOORMA_AUTH_JWT_ISSUER=soorma-identity-service
 export SOORMA_AUTH_JWT_AUDIENCE=soorma-services
 
-# Middleware verifier primary source (inside docker network)
-export SOORMA_AUTH_JWKS_URL=http://identity-service:8085/v1/identity/.well-known/jwks.json
-export SOORMA_AUTH_OPENID_CONFIGURATION_URL=http://identity-service:8085/v1/identity/.well-known/openid-configuration
-
-# Optional bounded fallback verifier key (recommended during compatibility)
-export SOORMA_AUTH_JWT_PUBLIC_KEY_ID=local-rs1
-export SOORMA_AUTH_JWT_PUBLIC_KEY_PEM="$IDENTITY_SIGNING_PUBLIC_KEY_PEM"
+# Inline JWKS for issuer publication and verifier startup determinism
+export IDENTITY_JWKS_PUBLICATION_JSON='{"keys":[...]}'
+export IDENTITY_VERIFIER_JWKS_JSON="$IDENTITY_JWKS_PUBLICATION_JSON"
+export SOORMA_AUTH_JWKS_JSON="$IDENTITY_JWKS_PUBLICATION_JSON"
+export SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON="$IDENTITY_SIGNING_PUBLIC_KEYRING_JSON"
 
 # Optional cache tuning
 export SOORMA_AUTH_JWKS_CACHE_TTL_SECONDS=300
 ```
 
-## 6. Start or Recreate the Stack
+## 7. Start or Recreate the Stack
 
 If this is your first run:
 
@@ -94,23 +116,23 @@ soorma dev --stop --clean
 soorma dev --start
 ```
 
-## 7. Variable-by-Variable Mapping
+## 8. Variable-by-Variable Mapping
 
 | Variable | Purpose | Consumed By |
 |---|---|---|
 | `IDENTITY_SIGNING_ALGORITHM` | selects signing algorithm (`RS256`) | identity-service provider facade |
-| `IDENTITY_SIGNING_KEY_ID` | default signing `kid` | identity-service provider facade |
 | `IDENTITY_ACTIVE_SIGNING_KID` | active signing key selector | identity-service provider facade |
-| `IDENTITY_SIGNING_PRIVATE_KEY_PEM` | RS256 private key for issuance | identity-service provider facade |
-| `IDENTITY_SIGNING_PUBLIC_KEY_PEM` | RS256 public key for JWKS/static fallback | identity-service provider facade |
-| `SOORMA_AUTH_JWKS_URL` | JWKS primary verifier source | all services using `soorma-service-common` middleware |
-| `SOORMA_AUTH_OPENID_CONFIGURATION_URL` | discovery metadata (issuer/jwks_uri) | all services using `soorma-service-common` middleware |
+| `IDENTITY_SIGNING_PRIVATE_KEYRING_JSON` | RS256 private signing keyring | identity-service provider facade |
+| `IDENTITY_SIGNING_PUBLIC_KEYRING_JSON` | RS256 public publication keyring | identity-service provider facade |
+| `IDENTITY_JWKS_PUBLICATION_JSON` | published JWKS payload | identity-service provider facade and discovery routes |
+| `IDENTITY_VERIFIER_JWKS_JSON` | delegated verifier JWKS input | identity-service provider facade |
+| `SOORMA_AUTH_JWKS_JSON` | JWKS primary verifier source | all services using `soorma-service-common` middleware |
 | `SOORMA_AUTH_JWT_ISSUER` | explicit trusted issuer | all services using `soorma-service-common` middleware |
 | `SOORMA_AUTH_JWT_AUDIENCE` | JWT audience check | all services using `soorma-service-common` middleware |
-| `SOORMA_AUTH_JWT_PUBLIC_KEY_PEM` + `SOORMA_AUTH_JWT_PUBLIC_KEY_ID` | static fallback verifier key | all services using `soorma-service-common` middleware |
+| `SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON` | static fallback verifier keyring | all services using `soorma-service-common` middleware |
 | `SOORMA_AUTH_JWKS_CACHE_TTL_SECONDS` | discovery/JWKS cache TTL | all services using `soorma-service-common` middleware |
 
-## 8. Verify It Is Actually Running Asymmetric Mode
+## 9. Verify It Is Actually Running Asymmetric Mode
 
 ### 8.1 Verify discovery endpoints
 
@@ -143,15 +165,10 @@ PYTHONPATH=services/identity-service/src:libs/soorma-common/src:libs/soorma-serv
 
 ## 9. Known Local Compatibility Notes
 
-1. This is Unit 3 compatibility phase. Some paths still retain bounded legacy fallback behavior by design.
-2. `soorma dev` currently seeds symmetric defaults unless you override as shown above.
-3. If you change any bootstrap-affecting JWT config, drift protection can trigger `FAILED_DRIFT`; use `--stop --clean` before restart.
+1. Some bounded compatibility seams remain in persistence and migration surfaces; this primer only covers local JWT bootstrap behavior.
+2. If you change any bootstrap-affecting JWT config, drift protection can trigger `FAILED_DRIFT`; use `--stop --clean` before restart.
+3. Deleting `.soorma/identity/` is the intended local rotation path for the generated keypair.
 
 ## 10. Recommended Next CLI Improvement
 
-To fully eliminate manual exports, add a `soorma dev` asymmetric bootstrap mode that:
-
-1. generates local RSA keypair under `.soorma/keys/`
-2. writes escaped PEM vars to `.soorma/.env`
-3. sets RS256 + JWKS/discovery defaults automatically
-4. includes generated key fingerprints in bootstrap-state drift checks
+Manual exports are only needed when you want custom key material or a custom verifier source.

--- a/docs/identity_service/README.md
+++ b/docs/identity_service/README.md
@@ -63,7 +63,7 @@ Admin-route exception:
 ## Security And Behavior Notes
 
 - JWT path is authoritative when JWT is present.
-- Coexistence mode remains compatible for legacy header-based context where applicable.
+- Public discovery routes remain bypassed, but secured non-public routes deny header-only access when bearer JWT is absent.
 - Delegated issuance requires trusted issuer state.
 - Mapping collision default is deny unless explicit override is requested and caller principal qualifies.
 - Platform identity record IDs are service-owned and generated server-side.
@@ -87,23 +87,33 @@ Admin-route exception:
 | `SYNC_DATABASE_URL` | No | derived from `DATABASE_URL` | migrations and sync DB tooling |
 | `IS_PROD` | No | `false` | FastAPI docs/redoc exposure toggle |
 | `IDENTITY_ADMIN_API_KEY` | Yes for admin-protected routes | `dev-identity-admin` | admin authorization dependency (`X-Identity-Admin-Key`) |
-| `IDENTITY_SIGNING_KEY` | Yes for signing determinism | `dev-identity-signing-key` | provider facade JWT signing |
-| `SOORMA_AUTH_JWT_SECRET` | Required for bearer JWT validation path | `dev-identity-signing-key` | tenancy middleware JWT validation |
+| `IDENTITY_SIGNING_ALGORITHM` | No | `RS256` in `soorma dev` | provider facade signing mode |
+| `IDENTITY_ACTIVE_SIGNING_KID` | No | `dev-rs256` | provider facade active signing key selector |
+| `IDENTITY_SIGNING_PRIVATE_KEYRING_JSON` | Required for RS256 signing | derived from persisted `.soorma/identity/identity-signing-private.pem` | provider facade signing keyring |
+| `IDENTITY_SIGNING_PUBLIC_KEYRING_JSON` | Required for RS256 publication | derived from persisted `.soorma/identity/identity-signing-public.pem` | provider facade publication keyring |
+| `IDENTITY_JWKS_PUBLICATION_JSON` | No | derived from persisted `.soorma/identity/identity-jwks.json` | discovery/JWKS publication |
+| `SOORMA_AUTH_JWKS_JSON` | Required for bearer JWT validation path | derived from persisted `.soorma/identity/identity-jwks.json` | tenancy middleware JWKS validation |
+| `SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON` | No | derived from persisted `.soorma/identity/identity-signing-public.pem` | static verifier fallback |
 | `SOORMA_AUTH_JWT_ISSUER` | No | `soorma-identity-service` | optional JWT issuer verification |
 | `SOORMA_AUTH_JWT_AUDIENCE` | No | `soorma-services` | optional JWT audience verification |
 
 Behavior notes:
 - If bearer JWT is present and invalid, requests fail closed and do not fall back to legacy headers.
-- If bearer JWT is absent, coexistence mode allows legacy header-derived context.
+- If bearer JWT is absent on secured non-public routes, requests fail closed unless the trusted admin-key exception applies.
 
 ## soorma dev Integration
 
-`soorma dev --start` auto-generates `.soorma/docker-compose.yml` and `.soorma/.env` with local defaults for identity and JWT testing.
+`soorma dev --start` auto-generates `.soorma/docker-compose.yml` and `.soorma/.env`, and persists local RSA signing material under `.soorma/identity/` on first bootstrap.
 
 Override flow:
 1. Export any env var override in your shell.
 2. Run `soorma dev --start`.
 3. The generated stack inherits those override values.
+
+Rotation flow:
+1. Delete the files under `.soorma/identity/`.
+2. Run `soorma dev --start` again.
+3. The CLI generates a fresh local RSA keypair and JWKS document.
 
 ## Local Development
 

--- a/examples/01-hello-tool/README.md
+++ b/examples/01-hello-tool/README.md
@@ -1,6 +1,6 @@
 # 01-hello-tool - Calculator Tool Example
 
-**Concepts:** Tool pattern, stateless operations, synchronous request/response, multiple handlers  
+**Concepts:** Tool pattern, stateless operations, synchronous request/response, multiple handlers, auth token provider  
 **Difficulty:** Beginner  
 **Time:** 5 minutes  
 **Prerequisites:** None (first example!)
@@ -17,6 +17,7 @@ This example demonstrates the **Tool pattern** - the simplest agent model in Soo
 - ✅ **InvocationContext** - Lightweight request context
 - ✅ **Caller-specified routing** - Response goes where caller wants
 - ✅ **Error handling** - Graceful handling of edge cases (division by zero)
+- ✅ **Shared auth provider** - Example bootstraps once and injects bearer-token management into both tool and client
 
 ---
 
@@ -44,6 +45,19 @@ This example demonstrates the **Tool pattern** - the simplest agent model in Soo
 - ❌ Long-running operations
 
 *(For those cases, use [Worker pattern](../02-hello-worker) instead)*
+
+---
+
+## Auth Provider Concept
+
+This example talks to secured Soorma infrastructure services, so the calculator tool and the driver client both need bearer tokens.
+
+Rather than hard-coding tenant IDs or building `Authorization` headers manually, the example uses the shared auth-provider pattern:
+
+1. `start.sh` primes `examples.shared.auth` for `01-hello-tool`.
+2. The shared helper bootstraps the example tenant once and persists metadata under `.soorma/01-hello-tool-identity.json`.
+3. The same provider requests, caches, and refreshes JWTs when the client or tool needs them.
+4. The provider is injected through `auth_token_provider=...` so the example code stays focused on Tool behavior rather than auth plumbing.
 
 ---
 
@@ -87,16 +101,22 @@ This example demonstrates the **Tool pattern** - the simplest agent model in Soo
 ### 1. Tool Creation
 
 ```python
+from examples.shared.auth import build_example_token_provider
+
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider("01-hello-tool", __file__)
+
 calculator = Tool(
     name="calculator-tool",
     description="Performs basic arithmetic operations",
     default_response_event="calculator.completed",  # Fallback
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 ```
 
 **Key points:**
 - `default_response_event` is optional - used if caller doesn't specify one
 - Tool has no state - just configuration
+- The auth token provider is injected once at initialization so the tool can connect to secured infrastructure without embedding auth logic into handlers
 
 ### 2. Handler Registration
 
@@ -191,6 +211,39 @@ async def handle_add(request: InvocationContext, context: PlatformContext):
 - `correlation_id` - For distributed tracing
 - `tenant_id`, `user_id` - Auth context
 
+### 6. Client Auth + Event Publish
+
+```python
+from examples.shared.auth import build_example_token_provider
+
+token_provider = build_example_token_provider("01-hello-tool", __file__)
+await token_provider.get_token()
+tenant_id = await token_provider.get_platform_tenant_id()
+user_id = await token_provider.get_bootstrap_admin_principal_id()
+
+client = EventClient(
+    agent_id="calculator-client",
+    source="calculator-client",
+    auth_token_provider=token_provider,
+)
+
+await client.publish(
+    event_type=event_type,
+    topic=EventTopic.ACTION_REQUESTS,
+    data={"a": a, "b": b},
+    correlation_id=correlation_id,
+    response_event="math.result",
+    response_topic="action-results",
+    tenant_id=tenant_id,
+    user_id=user_id,
+)
+```
+
+**Key points:**
+- The client uses the same shared auth-provider abstraction as the tool
+- Tenant and bootstrap-admin identifiers come from the persisted bootstrap payload, not hard-coded constants
+- `EventClient` receives the provider directly and resolves bearer tokens when connecting or publishing
+
 ---
 
 ## Running the Example
@@ -211,6 +264,8 @@ pip install -e sdk/python
 soorma dev --build
 ```
 
+The first example run also creates `.soorma/01-hello-tool-identity.json` so later runs reuse the same bootstrapped principal instead of onboarding a new tenant every time.
+
 ### Step 1: Start the Tool
 
 In terminal 1:
@@ -223,6 +278,7 @@ cd examples/01-hello-tool
 You should see:
 
 ```
+✓ Example identity bootstrap and token cache ready
 Starting Calculator Tool...
 Listening for events: ['math.add.requested', 'math.subtract.requested', 'math.multiply.requested', 'math.divide.requested']
 Publishing to events: ['calculator.completed']
@@ -418,6 +474,7 @@ Now that you understand the **Tool pattern**, explore:
 ✅ **Tools return immediately** - Handler returns result synchronously  
 ✅ **Multiple handlers per tool** - Use `@on_invoke()` for each event type  
 ✅ **Auto-response publishing** - Framework handles publishing for you  
+✅ **Auth is injected, not hand-coded** - The shared provider handles bootstrap, token caching, and refresh for both client and tool  
 ✅ **Caller-specified routing** - Response goes where caller wants  
 ✅ **Simple and fast** - Perfect for pure functions  
 

--- a/examples/01-hello-tool/calculator_tool.py
+++ b/examples/01-hello-tool/calculator_tool.py
@@ -9,11 +9,24 @@ This example demonstrates the Tool pattern with:
 """
 
 import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Tool, InvocationContext, PlatformContext
+
+from examples.shared.auth import build_example_token_provider
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+
+EXAMPLE_NAME = "01-hello-tool"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Create the calculator tool
@@ -21,6 +34,7 @@ calculator = Tool(
     name="calculator-tool",
     description="Performs basic arithmetic operations (add, subtract, multiply, divide)",
     default_response_event="calculator.completed",  # Fallback if caller doesn't specify
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/01-hello-tool/client.py
+++ b/examples/01-hello-tool/client.py
@@ -11,13 +11,21 @@ Usage:
 
 import asyncio
 import argparse
+import sys
+from pathlib import Path
 from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+
+EXAMPLE_NAME = "01-hello-tool"
 
 
 async def send_calculation_request(operation: str, a: float, b: float):
@@ -43,11 +51,16 @@ async def send_calculation_request(operation: str, a: float, b: float):
     
     event_type = operation_events[operation]
     response_event = "math.result"
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     
     # Create EventClient
     client = EventClient(
         agent_id="calculator-client",
         source="calculator-client",
+        auth_token_provider=token_provider,
     )
     
     print("=" * 60)
@@ -84,8 +97,8 @@ async def send_calculation_request(operation: str, a: float, b: float):
         correlation_id=correlation_id,
         response_event=response_event,
         response_topic="action-results",
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
     
     print("📤 Request sent!")

--- a/examples/01-hello-tool/start.sh
+++ b/examples/01-hello-tool/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="01-hello-tool"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -43,6 +44,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 echo "======================================================================"
 echo "  Starting Calculator Tool"

--- a/examples/01-hello-world/README.md
+++ b/examples/01-hello-world/README.md
@@ -1,6 +1,6 @@
 # 01 - Hello World
 
-**Concepts:** Worker pattern, Event handling, Request/Response  
+**Concepts:** Worker pattern, Event handling, Request/Response, Auth token provider  
 **Difficulty:** Beginner  
 **Prerequisites:** None
 
@@ -12,6 +12,7 @@ This example now bootstraps a local identity domain under the shared `.soorma/` 
 - How to handle events with `@worker.on_event()` decorator
 - **Best practice: Use `respond()` for request/response patterns**
 - How clients send requests and receive responses
+- Why secured infrastructure access is injected through an auth token provider instead of hard-coded headers or one-off token calls
 
 ## The Pattern
 
@@ -24,6 +25,19 @@ The Worker pattern is a simple way to build reactive agents in Soorma. A Worker:
 
 **Key advantage**: The `respond()` method is semantically correct for request/response patterns - it knows to publish responses to the `action-results` topic and requires a correlation_id to link responses to their requests.
 
+## Auth Provider Concept
+
+The example talks to secured Soorma infrastructure services, so both the worker and the client need a way to obtain bearer tokens without embedding auth logic into every event call.
+
+This is what the auth token provider does:
+
+1. It bootstraps the example's local identity metadata once and persists it under `.soorma/`.
+2. It requests JWTs from Identity Service when needed.
+3. It caches and refreshes those JWTs before expiry.
+4. It is injected into SDK clients and agents through `auth_token_provider`, so the rest of the example can focus on Worker and Event patterns instead of auth plumbing.
+
+In this example, the provider comes from `examples.shared.auth.build_example_token_provider(...)`. The worker hands it to `Worker(...)`, and the client hands it to `EventClient(...)`.
+
 ## Code Walkthrough
 
 ### Worker Agent ([worker.py](worker.py))
@@ -31,17 +45,24 @@ The Worker pattern is a simple way to build reactive agents in Soorma. A Worker:
 The Worker demonstrates the basic pattern:
 
 ```python
+from examples.shared.auth import build_example_token_provider
+
+EXAMPLE_NAME = "01-hello-world"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
+
 worker = Worker(
     name="hello-worker",
     description="A simple greeting agent",
     capabilities=["greeting"],
-    events_consumed=["greeting.requested"],
-    events_produced=["greeting.completed"],
+    events_consumed=[GREETING_REQUESTED_EVENT],
+    events_produced=[GREETING_COMPLETED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 @worker.on_event("greeting.requested", topic=EventTopic.ACTION_REQUESTS)
 async def handle_greeting(event: EventEnvelope, context: PlatformContext):
-    name = event.data.get("name", "World")
+    data = event.data or {}
+    name = data.get("name", "World")
     greeting = f"Hello, {name}! 👋"
     
     # Extract response_event from request (caller specifies expected response)
@@ -56,6 +77,7 @@ async def handle_greeting(event: EventEnvelope, context: PlatformContext):
 ```
 
 **How it applies the concepts:**
+- `EXAMPLE_TOKEN_PROVIDER` is injected once into the worker so all infrastructure-facing SDK calls use the same bearer-token lifecycle
 - `events_consumed` and `events_produced` declare the agent's interface
 - `@worker.on_event()` with `topic=EventTopic.ACTION_REQUESTS` subscribes to incoming requests
 - `event.response_event` lets clients specify what event type they expect as response
@@ -67,7 +89,6 @@ async def handle_greeting(event: EventEnvelope, context: PlatformContext):
 The Client demonstrates how to make requests and receive responses:
 
 ```python
-# Build a reusable local token provider
 from examples.shared.auth import build_example_token_provider
 
 token_provider = build_example_token_provider("01-hello-world", __file__)
@@ -89,6 +110,8 @@ await client.publish(
     correlation_id=str(uuid4()),
     response_event="greeting.completed",
     response_topic="action-results",
+    tenant_id=tenant_id,
+    user_id=user_id,
 )
 
 # Listen for response
@@ -99,8 +122,9 @@ async def on_response(event: EventEnvelope):
 ```
 
 **How it applies the concepts:**
-- `examples.shared.auth.build_example_token_provider()` returns a reusable trusted-proxy style provider that bootstraps once, persists the example principal under `.soorma/01-hello-world-identity.json`, and refreshes JWTs only when needed
-- The shared provider also exposes the bootstrapped `platform_tenant_id` and bootstrap admin principal ID so the example no longer relies on hard-coded tenant values
+- `examples.shared.auth.build_example_token_provider()` returns a reusable auth token provider that bootstraps once, persists the example principal under `.soorma/01-hello-world-identity.json`, and refreshes JWTs only when needed
+- The same provider abstraction also exposes the bootstrapped `platform_tenant_id` and bootstrap admin principal ID so the example no longer relies on hard-coded tenant values
+- The client passes that provider into `EventClient(...)` instead of manually managing `Authorization` headers
 - `correlation_id` allows matching responses to requests
 - `response_event` and `response_topic` tell the Worker where/what to send back
 - Handler receives responses on the specified topic
@@ -186,6 +210,7 @@ Expected output:
 ✅ **Decorators simplify wiring** - `@worker.on_event()` automatically handles subscription and topic binding  
 ✅ **Use the right method** - `respond()` is better than `publish()` for request/response because it's semantically clear  
 ✅ **Context provides platform access** - Use `context.bus`, `context.memory`, `context.registry` for all platform operations  
+✅ **Auth is injected, not hand-coded** - The example uses one reusable auth token provider for bootstrap, token caching, and refresh  
 ✅ **Everything is asynchronous** - All I/O operations use `async/await`  
 
 ## Common Mistakes to Avoid

--- a/examples/01-hello-world/README.md
+++ b/examples/01-hello-world/README.md
@@ -4,6 +4,8 @@
 **Difficulty:** Beginner  
 **Prerequisites:** None
 
+This example now bootstraps a local identity domain under the shared `.soorma/` directory on first run, then uses a reusable token provider to request, cache, and refresh JWTs for later runs.
+
 ## What You'll Learn
 
 - How to create a Worker agent
@@ -65,6 +67,18 @@ async def handle_greeting(event: EventEnvelope, context: PlatformContext):
 The Client demonstrates how to make requests and receive responses:
 
 ```python
+# Build a reusable local token provider
+from examples.shared.auth import build_example_token_provider
+
+token_provider = build_example_token_provider("01-hello-world", __file__)
+await token_provider.get_token()
+
+client = EventClient(
+    agent_id="hello-client",
+    source="hello-client",
+    auth_token_provider=token_provider,
+)
+
 # Send request with response_event metadata
 await client.publish(
     event_type="greeting.requested",
@@ -83,6 +97,7 @@ async def on_response(event: EventEnvelope):
 ```
 
 **How it applies the concepts:**
+- `examples.shared.auth.build_example_token_provider()` returns a reusable trusted-proxy style provider that bootstraps once, persists the example principal under `.soorma/01-hello-world-identity.json`, and refreshes JWTs only when needed
 - `correlation_id` allows matching responses to requests
 - `response_event` and `response_topic` tell the Worker where/what to send back
 - Handler receives responses on the specified topic
@@ -101,6 +116,8 @@ soorma dev --build
 ```
 
 The `--build` flag builds services from your local code. **Leave this running** for all examples.
+
+The first example run also creates `.soorma/01-hello-world-identity.json` so subsequent runs reuse the same bootstrapped principal instead of onboarding a new tenant every time.
 
 ### Quick Start
 
@@ -132,6 +149,8 @@ cd examples/01-hello-world
 python worker.py
 ```
 
+The worker is configured with the shared example token provider, which injects bearer tokens into its registry, event-bus, memory, and tracker clients on demand.
+
 You should see:
 ```
 🚀 Hello Worker started!
@@ -145,6 +164,8 @@ You should see:
 ```bash
 python client.py Alice
 ```
+
+The client reuses the same persisted example principal, then lets the shared token provider request and cache bearer tokens for Event Service access.
 
 Expected output:
 ```
@@ -171,6 +192,7 @@ Expected output:
 ❌ **Not extracting `response_event` from request** - Let clients specify where responses go  
 ❌ **Not awaiting async calls** - All I/O operations must be `await`ed  
 ❌ **Using wrong topic** - Requests go to `ACTION_REQUESTS`, responses to `ACTION_RESULTS`  
+❌ **Skipping token provider setup** - secured local services now require the example to configure a bearer-token provider before connecting  
 
 ## Next Steps
 

--- a/examples/01-hello-world/README.md
+++ b/examples/01-hello-world/README.md
@@ -72,6 +72,8 @@ from examples.shared.auth import build_example_token_provider
 
 token_provider = build_example_token_provider("01-hello-world", __file__)
 await token_provider.get_token()
+tenant_id = await token_provider.get_platform_tenant_id()
+user_id = await token_provider.get_bootstrap_admin_principal_id()
 
 client = EventClient(
     agent_id="hello-client",
@@ -98,6 +100,7 @@ async def on_response(event: EventEnvelope):
 
 **How it applies the concepts:**
 - `examples.shared.auth.build_example_token_provider()` returns a reusable trusted-proxy style provider that bootstraps once, persists the example principal under `.soorma/01-hello-world-identity.json`, and refreshes JWTs only when needed
+- The shared provider also exposes the bootstrapped `platform_tenant_id` and bootstrap admin principal ID so the example no longer relies on hard-coded tenant values
 - `correlation_id` allows matching responses to requests
 - `response_event` and `response_topic` tell the Worker where/what to send back
 - Handler receives responses on the specified topic

--- a/examples/01-hello-world/client.py
+++ b/examples/01-hello-world/client.py
@@ -20,8 +20,6 @@ from soorma_common.events import EventEnvelope, EventTopic
 from examples.shared.auth import build_example_token_provider
 
 
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
 EXAMPLE_NAME = "01-hello-world"
 
 
@@ -29,13 +27,14 @@ async def send_greeting_request(name: str = "World"):
     """Send a greeting request and wait for the response."""
     token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
     await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     
     # Create EventClient
     client = EventClient(
         agent_id="hello-client",
         source="hello-client",
         auth_token_provider=token_provider,
-        platform_tenant_id=TENANT_ID,
     )
     
     print("=" * 50)
@@ -71,8 +70,8 @@ async def send_greeting_request(name: str = "World"):
         correlation_id=correlation_id,
         response_event="greeting.completed",
         response_topic="action-results",
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
     
     print("📤 Request sent!")

--- a/examples/01-hello-world/client.py
+++ b/examples/01-hello-world/client.py
@@ -8,21 +8,34 @@ This demonstrates how to interact with Soorma agents using the EventClient.
 
 import sys
 import asyncio
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
 
 
 TENANT_ID = "00000000-0000-0000-0000-000000000000"
 USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "01-hello-world"
 
 
 async def send_greeting_request(name: str = "World"):
     """Send a greeting request and wait for the response."""
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
     
     # Create EventClient
     client = EventClient(
         agent_id="hello-client",
         source="hello-client",
+        auth_token_provider=token_provider,
+        platform_tenant_id=TENANT_ID,
     )
     
     print("=" * 50)

--- a/examples/01-hello-world/start.sh
+++ b/examples/01-hello-world/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="01-hello-world"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -31,6 +32,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 echo "======================================================================"
 echo "  Starting Worker Agent"

--- a/examples/01-hello-world/worker.py
+++ b/examples/01-hello-world/worker.py
@@ -6,10 +6,23 @@ The simplest possible Soorma agent - demonstrates the Worker pattern.
 A Worker listens for events and responds to them.
 """
 
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "01-hello-world"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -33,6 +46,7 @@ worker = Worker(
     capabilities=["greeting"],
     events_consumed=[GREETING_REQUESTED_EVENT],
     events_produced=[GREETING_COMPLETED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/02-events-simple/publisher.py
+++ b/examples/02-events-simple/publisher.py
@@ -7,21 +7,33 @@ This simulates an order service publishing events in an order workflow.
 """
 
 import asyncio
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "02-events-simple"
 
 
 async def publish_order_workflow():
     """Publish the initial event that triggers the order workflow chain."""
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     
     # Create EventClient for publishing
     client = EventClient(
         agent_id="order-service",
         source="order-service",
+        auth_token_provider=token_provider,
     )
     
     print("=" * 60)
@@ -45,8 +57,8 @@ async def publish_order_workflow():
             "items": ["laptop", "mouse"],
             "total": 1500.00,
         },
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
     print("   ✓ Published to 'business-facts' topic\n")
     

--- a/examples/02-events-simple/start.sh
+++ b/examples/02-events-simple/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="02-events-simple"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -31,6 +32,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 echo "======================================================================"
 echo "  Starting Subscriber Agent"

--- a/examples/02-events-simple/subscriber.py
+++ b/examples/02-events-simple/subscriber.py
@@ -6,10 +6,23 @@ Demonstrates how to subscribe to and handle multiple event types.
 This simulates various services reacting to events in an order workflow.
 """
 
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "02-events-simple"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -54,6 +67,7 @@ worker = Worker(
         PAYMENT_COMPLETED_EVENT,
         ORDER_COMPLETED_EVENT,
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/03-events-structured/client.py
+++ b/examples/03-events-structured/client.py
@@ -8,12 +8,18 @@ Each ticket will be analyzed by the LLM to determine the best routing.
 
 import sys
 import asyncio
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "03-events-structured"
 
 
 SAMPLE_TICKETS = [
@@ -52,11 +58,16 @@ SAMPLE_TICKETS = [
 
 async def create_ticket(description: str, priority: str = "normal", customer: str = "Test User"):
     """Create a support ticket and wait for routing."""
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     
     # Create EventClient
     client = EventClient(
         agent_id="ticket-client",
         source="ticket-client",
+        auth_token_provider=token_provider,
     )
     
     # Generate ticket ID
@@ -87,8 +98,8 @@ async def create_ticket(description: str, priority: str = "normal", customer: st
             "description": description,
             "priority": priority,
         },
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
     print("   ✓ Ticket created!")
     print()

--- a/examples/03-events-structured/start.sh
+++ b/examples/03-events-structured/start.sh
@@ -11,6 +11,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="03-events-structured"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -32,6 +33,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 # Check for OpenAI API key

--- a/examples/03-events-structured/ticket_router.py
+++ b/examples/03-events-structured/ticket_router.py
@@ -16,7 +16,14 @@ The generic LLM utilities are in llm_utils.py (future SDK).
 """
 
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
@@ -33,6 +40,12 @@ from llm_utils import (
     validate_and_publish,
 )
 
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "03-events-structured"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
+
 
 # Create worker for ticket routing
 # SDK will automatically register these event definitions
@@ -48,6 +61,7 @@ worker = Worker(
         MANAGEMENT_ESCALATION_EVENT,
         AUTOCLOSE_EVENT,
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/04-memory-working/client.py
+++ b/examples/04-memory-working/client.py
@@ -10,13 +10,32 @@ Usage:
 
 import asyncio
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "04-memory-working"
 
 
 async def start_workflow():
     """Start the demo workflow."""
-    client = EventClient(agent_id="workflow-client", source="workflow-client")
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
+    client = EventClient(
+        agent_id="workflow-client",
+        source="workflow-client",
+        auth_token_provider=token_provider,
+    )
     
     # Event to signal workflow completion
     workflow_completed = asyncio.Event()
@@ -44,8 +63,8 @@ async def start_workflow():
             response_event="workflow.completed",
             topic=EventTopic.ACTION_REQUESTS,
             data={"workflow_name": "blog-post-demo"},
-            tenant_id="00000000-0000-0000-0000-000000000000",
-            user_id="00000000-0000-0000-0000-000000000001",
+            tenant_id=tenant_id,
+            user_id=user_id,
         )
         
         print("   Waiting for workflow completion...")

--- a/examples/04-memory-working/memory_api_demo.py
+++ b/examples/04-memory-working/memory_api_demo.py
@@ -6,19 +6,31 @@ how WorkflowState simplifies the code.
 """
 
 import asyncio
+import sys
 import uuid
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma.memory.client import MemoryServiceClient
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "04-memory-working"
 
 
 async def demonstrate_raw_memory_api():
     """Show raw Memory API operations for working memory."""
-    # For example purposes - use hardcoded tenant/user IDs
-    # In production, these come from authentication/event context
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-    user_id = "00000000-0000-0000-0000-000000000000"
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     
     # Create Memory client directly (not through PlatformContext)
-    memory = MemoryServiceClient()
+    memory = MemoryServiceClient(auth_token_provider=token_provider)
     plan_id = str(uuid.uuid4())
     
     print(f"📋 Plan ID: {plan_id}\n")

--- a/examples/04-memory-working/planner.py
+++ b/examples/04-memory-working/planner.py
@@ -17,13 +17,26 @@ No in-memory state - everything is in working memory!
 """
 
 import asyncio
-from typing import Any, Dict
+import sys
 import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.workflow import WorkflowState
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "04-memory-working"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -58,6 +71,7 @@ planner = Worker(
     capabilities=["planning", "orchestration"],
     events_consumed=[WORKFLOW_START_EVENT, TASK_COMPLETED_EVENT],
     events_produced=[TASK_ASSIGNED_EVENT, WORKFLOW_COMPLETED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/04-memory-working/start.sh
+++ b/examples/04-memory-working/start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Start script for 04-memory-working example
 
+set -e
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_NAME="04-memory-working"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+
 echo "🚀 Starting 04-memory-working example..."
 echo ""
 echo "This example demonstrates working memory with request/response pattern."
@@ -20,6 +26,10 @@ fi
 
 echo "✓ Memory Service is running"
 echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
+echo ""
 
 echo "This example requires 2 agents running simultaneously:"
 echo "  1. Planner (orchestrates workflow, listens for responses)"
@@ -33,12 +43,12 @@ trap 'kill $(jobs -p) 2>/dev/null' EXIT
 
 # Start agents in background
 echo "Starting planner..."
-python3 planner.py &
+python3 "$EXAMPLE_DIR/planner.py" &
 PLANNER_PID=$!
 sleep 2
 
 echo "Starting worker..."
-python3 worker.py &
+python3 "$EXAMPLE_DIR/worker.py" &
 WORKER_PID=$!
 sleep 2
 

--- a/examples/04-memory-working/worker.py
+++ b/examples/04-memory-working/worker.py
@@ -12,12 +12,25 @@ Key: Worker responds directly to the PLANNER (requester).
 """
 
 import asyncio
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.workflow import WorkflowState
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "04-memory-working"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -40,6 +53,7 @@ worker = Worker(
     capabilities=["task-execution", "research", "drafting", "review"],
     events_consumed=[TASK_ASSIGNED_EVENT],
     events_produced=[TASK_COMPLETED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/05-memory-semantic/answer_agent.py
+++ b/examples/05-memory-semantic/answer_agent.py
@@ -10,7 +10,14 @@ Uses event-driven choreography pattern.
 """
 
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from litellm import completion
 from soorma import Worker
 from soorma.context import PlatformContext
@@ -20,6 +27,12 @@ from events import (
     QUESTION_ANSWERED_EVENT,
     QuestionAnsweredPayload,
 )
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "05-memory-semantic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 def _build_knowledge_context(knowledge_results: list) -> tuple[list[dict], str]:
@@ -102,6 +115,7 @@ worker = Worker(
     capabilities=["question-answering", "rag"],
     events_consumed=[ANSWER_QUESTION_EVENT],
     events_produced=[QUESTION_ANSWERED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/05-memory-semantic/client.py
+++ b/examples/05-memory-semantic/client.py
@@ -20,28 +20,34 @@ Usage:
 """
 
 import asyncio
-import os
 import sys
+from pathlib import Path
 from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-# User ID can be set via environment variable (simulates authentication)
-# Note: Memory service currently expects UUID format
-DEFAULT_TENANT_ID = "00000000-0000-0000-0000-000000000000"
-TENANT_ID = os.getenv("TENANT_ID", DEFAULT_TENANT_ID)
-DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000001"
-USER_ID = os.getenv("USER_ID", DEFAULT_USER_ID)
+EXAMPLE_NAME = "05-memory-semantic"
 
 
 async def send_request(request: str):
     """Send a user request to the knowledge management system."""
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     
     # Create EventClient
     client = EventClient(
         agent_id="knowledge-client",
         source="knowledge-client",
+        auth_token_provider=token_provider,
     )
     
     print(f"\n📤 Sending request: {request}")
@@ -72,7 +78,7 @@ async def send_request(request: str):
     # Generate correlation ID
     correlation_id = str(uuid4())
     
-    print(f"   User: {USER_ID}")
+    print(f"   User: {user_id}")
     
     # Publish user request event with user_id in envelope
     await client.publish(
@@ -80,8 +86,8 @@ async def send_request(request: str):
         topic=EventTopic.ACTION_REQUESTS,
         data={"request": request},
         correlation_id=correlation_id,
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,  # User ID propagates through event chain
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
     
     print(f"   Request sent (correlation_id: {correlation_id})")

--- a/examples/05-memory-semantic/knowledge_store.py
+++ b/examples/05-memory-semantic/knowledge_store.py
@@ -5,6 +5,13 @@ A stateless tool that stores knowledge in semantic memory.
 Uses event-driven choreography pattern.
 """
 
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Tool
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
@@ -14,6 +21,12 @@ from events import (
     KnowledgeStoredPayload,
 )
 
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "05-memory-semantic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
+
 
 # Create a Tool for storing knowledge
 tool = Tool(
@@ -22,6 +35,7 @@ tool = Tool(
     capabilities=["knowledge-storage"],
     events_consumed=[STORE_KNOWLEDGE_EVENT],
     events_produced=[KNOWLEDGE_STORED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/05-memory-semantic/router.py
+++ b/examples/05-memory-semantic/router.py
@@ -10,12 +10,25 @@ It demonstrates:
 3. Event-driven choreography (publish selected event)
 """
 
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
 from events import USER_REQUEST_EVENT, STORE_KNOWLEDGE_EVENT, ANSWER_QUESTION_EVENT
 from llm_utils import select_event_with_llm, validate_and_publish
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "05-memory-semantic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Create a Worker for routing user requests
@@ -25,6 +38,7 @@ worker = Worker(
     capabilities=["routing", "intent-detection"],
     events_consumed=[USER_REQUEST_EVENT],
     events_produced=[STORE_KNOWLEDGE_EVENT, ANSWER_QUESTION_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 # LLM prompt template for routing decisions

--- a/examples/05-memory-semantic/start.sh
+++ b/examples/05-memory-semantic/start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Start script for 04-memory-semantic example
 
+set -e
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_NAME="05-memory-semantic"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+
 echo "🚀 Starting 04-memory-semantic example..."
 echo ""
 echo "This example demonstrates LLM-based routing with semantic memory and RAG."
@@ -19,6 +25,10 @@ if ! curl -s http://localhost:8083/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Memory Service is running"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 # Check for OpenAI API key
@@ -43,17 +53,17 @@ echo "Starting agents..."
 echo ""
 
 echo "  1. Knowledge Store (tool for storing facts)..."
-python3 knowledge_store.py &
+python3 "$EXAMPLE_DIR/knowledge_store.py" &
 STORE_PID=$!
 sleep 2
 
 echo "  2. Answer Agent (RAG-powered question answering)..."
-python3 answer_agent.py &
+python3 "$EXAMPLE_DIR/answer_agent.py" &
 ANSWER_PID=$!
 sleep 2
 
 echo "  3. Router (LLM-based intent detection)..."
-python3 router.py &
+python3 "$EXAMPLE_DIR/router.py" &
 ROUTER_PID=$!
 
 # Give agents more time to complete initialization

--- a/examples/06-memory-episodic/client.py
+++ b/examples/06-memory-episodic/client.py
@@ -13,31 +13,43 @@ import asyncio
 import sys
 import uuid
 from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma.memory import MemoryServiceClient
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-# Hardcoded user ID (in production, this comes from authentication)
-USER_ID = "00000000-0000-0000-0000-000000000001"
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
+EXAMPLE_NAME = "06-memory-episodic"
 
 
 class ChatbotClient:
     """Interactive chatbot client."""
     
     def __init__(self):
+        self.token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
         self.client = EventClient(
             agent_id="chatbot-client",
-            source="chatbot-client"
+            source="chatbot-client",
+            auth_token_provider=self.token_provider,
         )
-        self.memory_client = MemoryServiceClient()
+        self.memory_client = MemoryServiceClient(auth_token_provider=self.token_provider)
         self.session_id = None
         self.waiting_for_response = False
         self.response_event = None
+        self.tenant_id = None
+        self.user_id = None
     
     async def connect(self):
         """Connect to the platform."""
+        await self.token_provider.get_token()
+        self.tenant_id = await self.token_provider.get_platform_tenant_id()
+        self.user_id = await self.token_provider.get_bootstrap_admin_principal_id()
         await self.client.connect(topics=[EventTopic.ACTION_RESULTS])
         
         # Register response handler
@@ -73,7 +85,7 @@ class ChatbotClient:
         print("\n" + "=" * 60)
         print("🤖 Intelligent Chatbot with Multi-Memory Architecture")
         print("=" * 60)
-        print(f"User ID: {USER_ID}")
+        print(f"User ID: {self.user_id or 'unknown'}")
         print("\nThis chatbot demonstrates:")
         print("  • Episodic Memory: Remembers all interactions")
         print("  • Semantic Memory: Stores and retrieves knowledge")
@@ -110,8 +122,8 @@ class ChatbotClient:
                 plan_id=plan_id,
                 goal_event="chat.conversation",
                 goal_data={"type": "episodic_memory_demo"},
-                service_tenant_id=TENANT_ID,
-                service_user_id=USER_ID
+                service_tenant_id=self.tenant_id,
+                service_user_id=self.user_id
             )
             return True
         except Exception as e:
@@ -123,8 +135,8 @@ class ChatbotClient:
         try:
             print("\n📋 Fetching plans from working memory...")
             plans = await self.memory_client.list_plans(
-                service_tenant_id=TENANT_ID,
-                service_user_id=USER_ID,
+                service_tenant_id=self.tenant_id,
+                service_user_id=self.user_id,
                 limit=20
             )
             return plans if plans else []
@@ -215,8 +227,8 @@ class ChatbotClient:
                             # Delete plan (includes working memory cleanup)
                             await self.memory_client.delete_plan(
                                 plan_id=plan_id,
-                                service_tenant_id=TENANT_ID,
-                                service_user_id=USER_ID
+                                service_tenant_id=self.tenant_id,
+                                service_user_id=self.user_id
                             )
                             print(f"✅ Plan deleted: {plan_id}\n")
                             # If we deleted the current session, need to switch
@@ -247,8 +259,8 @@ class ChatbotClient:
                 "session_id": self.session_id,
                 "message": message
             },
-            tenant_id=TENANT_ID,
-            user_id=USER_ID,
+            tenant_id=self.tenant_id,
+            user_id=self.user_id,
         )
         
         # Wait for response with timeout

--- a/examples/06-memory-episodic/concierge.py
+++ b/examples/06-memory-episodic/concierge.py
@@ -9,13 +9,26 @@ This agent:
 
 import asyncio
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from litellm import completion
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
 from soorma.workflow import WorkflowState
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "06-memory-episodic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -38,6 +51,7 @@ concierge = Worker(
     capabilities=["conversation-analysis", "history-retrieval"],
     events_consumed=[CONCIERGE_QUERY_EVENT],
     events_produced=[CHAT_RESPONSE_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/06-memory-episodic/knowledge_store.py
+++ b/examples/06-memory-episodic/knowledge_store.py
@@ -8,12 +8,25 @@ This agent:
 """
 
 import asyncio
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
 from soorma.workflow import WorkflowState
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "06-memory-episodic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -36,6 +49,7 @@ knowledge_store = Worker(
     capabilities=["knowledge-storage", "fact-extraction"],
     events_consumed=[KNOWLEDGE_STORE_EVENT],
     events_produced=[CHAT_RESPONSE_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/06-memory-episodic/rag_agent.py
+++ b/examples/06-memory-episodic/rag_agent.py
@@ -10,13 +10,26 @@ This agent:
 
 import asyncio
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from litellm import completion
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
 from soorma.workflow import WorkflowState
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "06-memory-episodic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -39,6 +52,7 @@ rag_agent = Worker(
     capabilities=["question-answering", "retrieval", "context-synthesis"],
     events_consumed=[QUESTION_ANSWER_EVENT],
     events_produced=[CHAT_RESPONSE_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/06-memory-episodic/router.py
+++ b/examples/06-memory-episodic/router.py
@@ -12,13 +12,26 @@ Uses LLM for accurate intent classification.
 
 import asyncio
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from litellm import completion
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
 from soorma.workflow import WorkflowState
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "06-memory-episodic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -59,6 +72,7 @@ router = Worker(
     capabilities=["intent-classification", "routing"],
     events_consumed=[CHAT_MESSAGE_EVENT],
     events_produced=[KNOWLEDGE_STORE_EVENT, QUESTION_ANSWER_EVENT, CONCIERGE_QUERY_EVENT, CHAT_RESPONSE_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/06-memory-episodic/search_memory.py
+++ b/examples/06-memory-episodic/search_memory.py
@@ -10,15 +10,24 @@ Usage:
 
 import asyncio
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import PlatformContext
 
-# Hardcoded user ID (matches client.py)
-USER_ID = "00000000-0000-0000-0000-000000000001"
+from examples.shared.auth import build_example_token_provider
+
+EXAMPLE_NAME = "06-memory-episodic"
 
 
 async def search_memory(query: str, user_id: str, limit: int = 5):
     """Search episodic memory for relevant past interactions."""
-    context = PlatformContext()
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    context = PlatformContext(auth_token_provider=token_provider)
     print(f"🔍 Searching memory for: '{query}' (user: {user_id})\n")
     
     try:
@@ -80,6 +89,8 @@ if __name__ == "__main__":
     
     query = sys.argv[1]
     limit = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    USER_ID = asyncio.run(token_provider.get_bootstrap_admin_principal_id())
     
     print(f"Searching for user: {USER_ID}\n")
     asyncio.run(search_memory(query, USER_ID, limit))

--- a/examples/06-memory-episodic/start.sh
+++ b/examples/06-memory-episodic/start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Start script for 06-memory-episodic chatbot example
 
+set -e
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_NAME="06-memory-episodic"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+
 echo "🚀 Starting 06-memory-episodic chatbot..."
 echo ""
 echo "This example demonstrates a multi-agent chatbot with:"
@@ -22,6 +28,10 @@ if ! curl -s http://localhost:8083/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Memory Service is running"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 # Check for OpenAI API key
@@ -56,22 +66,22 @@ trap 'kill $(jobs -p) 2>/dev/null' EXIT
 
 # Start agents in background
 echo "Starting router..."
-python3 router.py &
+python3 "$EXAMPLE_DIR/router.py" &
 ROUTER_PID=$!
 sleep 2
 
 echo "Starting RAG agent..."
-python3 rag_agent.py &
+python3 "$EXAMPLE_DIR/rag_agent.py" &
 RAG_PID=$!
 sleep 2
 
 echo "Starting concierge..."
-python3 concierge.py &
+python3 "$EXAMPLE_DIR/concierge.py" &
 CONCIERGE_PID=$!
 sleep 2
 
 echo "Starting knowledge store..."
-python3 knowledge_store.py &
+python3 "$EXAMPLE_DIR/knowledge_store.py" &
 KNOWLEDGE_PID=$!
 sleep 2
 

--- a/examples/06-memory-episodic/view_history.py
+++ b/examples/06-memory-episodic/view_history.py
@@ -9,15 +9,24 @@ Usage:
 
 import asyncio
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import PlatformContext
 
-# Hardcoded user ID (matches client.py)
-USER_ID = "00000000-0000-0000-0000-000000000001"
+from examples.shared.auth import build_example_token_provider
+
+EXAMPLE_NAME = "06-memory-episodic"
 
 
 async def view_history(user_id: str, limit: int = 20):
     """View recent conversation history for a user."""
-    context = PlatformContext()
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    context = PlatformContext(auth_token_provider=token_provider)
     print(f"📜 Conversation History for {user_id}\n")
     print("=" * 60)
     
@@ -74,6 +83,8 @@ async def view_history(user_id: str, limit: int = 20):
 if __name__ == "__main__":
     # Optional: specify limit as argument
     limit = int(sys.argv[1]) if len(sys.argv) > 1 else 20
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    USER_ID = asyncio.run(token_provider.get_bootstrap_admin_principal_id())
     
     print(f"Viewing history for user: {USER_ID}\n")
     asyncio.run(view_history(USER_ID, limit))

--- a/examples/08-worker-basic/publisher.py
+++ b/examples/08-worker-basic/publisher.py
@@ -6,16 +6,32 @@ Sends an action request and waits for the worker's async completion.
 """
 
 import asyncio
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma import EventClient
 from soorma_common.events import EventTopic, EventEnvelope
 
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "08-worker-basic"
+
 
 async def publish_order_request() -> None:
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     client = EventClient(
         agent_id="order-service",
         source="order-service",
+        auth_token_provider=token_provider,
     )
 
     print("=" * 60)
@@ -44,8 +60,8 @@ async def publish_order_request() -> None:
             "items": ["laptop", "mouse"],
             "total": 1500.00,
         },
-        tenant_id="00000000-0000-0000-0000-000000000000",
-        user_id="00000000-0000-0000-0000-000000000001",
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
 
     try:

--- a/examples/08-worker-basic/start.sh
+++ b/examples/08-worker-basic/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Start script for 02-events-simple example
+# Start script for 08-worker-basic example
 #
 # Prerequisites: Platform services must be running
 #   Terminal 1: soorma dev --build
@@ -9,7 +9,8 @@
 set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EXAMPLE_NAME="02-events-simple"
+EXAMPLE_NAME="08-worker-basic"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -31,6 +32,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 echo "======================================================================"
 echo "  Starting Subscriber Agent"

--- a/examples/08-worker-basic/subscriber.py
+++ b/examples/08-worker-basic/subscriber.py
@@ -6,14 +6,28 @@ Demonstrates async choreography using action-requests/action-results with
 task delegation and explicit completion.
 """
 
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.task_context import DelegationSpec, ResultContext, TaskContext
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "08-worker-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 worker = Worker(
     name="order-processor",
     description="Processes order requests with async delegation",
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/09-planner-basic/client.py
+++ b/examples/09-planner-basic/client.py
@@ -8,14 +8,19 @@ Follows the standard EventClient pattern used in other examples.
 
 import asyncio
 import sys
+from pathlib import Path
 from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-# Authentication context (in production, this comes from user authentication)
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "09-planner-basic"
 
 
 async def send_research_goal(topic: str):
@@ -25,10 +30,15 @@ async def send_research_goal(topic: str):
     Args:
         topic: Research topic (e.g., "AI agents", "quantum computing")
     """
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     # Create EventClient
     client = EventClient(
         agent_id="research-client",
         source="research-client",
+        auth_token_provider=token_provider,
     )
     
     print("=" * 60)
@@ -77,8 +87,8 @@ async def send_research_goal(topic: str):
         correlation_id=correlation_id,
         response_event="research.result",
         response_topic="action-results",
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
     
     print("📤 Goal sent!")

--- a/examples/09-planner-basic/planner.py
+++ b/examples/09-planner-basic/planner.py
@@ -8,11 +8,24 @@ Demonstrates Stage 4 Phase 1 Planner patterns:
 - GoalContext wrapper for clean goal access
 """
 
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma.agents.planner import Planner, GoalContext
 from soorma.plan_context import PlanContext
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
 from soorma_common.state import StateConfig, StateAction, StateTransition
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "09-planner-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Create Planner agent
@@ -20,6 +33,7 @@ planner = Planner(
     name="basic-planner",
     description="Basic planner demonstrating state machine orchestration",
     capabilities=["planning", "research_orchestration"],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/09-planner-basic/start.sh
+++ b/examples/09-planner-basic/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="09-planner-basic"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -37,6 +38,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "✓ Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 # Use trap to cleanup background processes

--- a/examples/09-planner-basic/worker.py
+++ b/examples/09-planner-basic/worker.py
@@ -6,10 +6,23 @@ In a real system, this would call external APIs, databases, etc.
 """
 
 import asyncio
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "09-planner-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 # Define event types
@@ -33,6 +46,7 @@ worker = Worker(
     capabilities=["research"],
     events_consumed=[RESEARCH_TASK_EVENT],
     events_produced=[RESEARCH_COMPLETE_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/10-choreography-basic/analyzer.py
+++ b/examples/10-choreography-basic/analyzer.py
@@ -5,13 +5,25 @@ Simulates sentiment analysis for feedback items.
 """
 
 import logging
+import sys
+from pathlib import Path
 from typing import Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 
 from events import ANALYSIS_REQUESTED_EVENT, ANALYSIS_RESPONDED_EVENT
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "10-choreography-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 worker = Worker(
@@ -20,6 +32,7 @@ worker = Worker(
     capabilities=["feedback_analysis"],
     events_consumed=[ANALYSIS_REQUESTED_EVENT],
     events_produced=[ANALYSIS_RESPONDED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/10-choreography-basic/client.py
+++ b/examples/10-choreography-basic/client.py
@@ -13,17 +13,23 @@ Also demonstrates Tracker Service observability:
 import asyncio
 from uuid import uuid4
 from typing import Optional
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma import EventClient
 from soorma.tracker.client import TrackerServiceClient
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "10-choreography-basic"
 
 
-async def show_observability(plan_id: str) -> None:
+async def show_observability(plan_id: str, token_provider, tenant_id: str, user_id: str) -> None:
     """
     Query Tracker Service to show workflow observability.
     
@@ -35,7 +41,7 @@ async def show_observability(plan_id: str) -> None:
     Args:
         plan_id: Correlation ID (used as plan_id in choreography)
     """
-    tracker = TrackerServiceClient()
+    tracker = TrackerServiceClient(auth_token_provider=token_provider)
     
     print("\n" + "="*70)
     print("  📊 WORKFLOW OBSERVABILITY (Tracker Service)")
@@ -45,8 +51,8 @@ async def show_observability(plan_id: str) -> None:
         # Get plan progress summary
         progress = await tracker.get_plan_progress(
             plan_id=plan_id,
-            service_tenant_id=TENANT_ID,
-            service_user_id=USER_ID,
+            service_tenant_id=tenant_id,
+            service_user_id=user_id,
         )
         
         if progress:
@@ -63,8 +69,8 @@ async def show_observability(plan_id: str) -> None:
         # Get task execution history
         tasks = await tracker.get_plan_tasks(
             plan_id=plan_id,
-            service_tenant_id=TENANT_ID,
-            service_user_id=USER_ID,
+            service_tenant_id=tenant_id,
+            service_user_id=user_id,
         )
         
         if tasks:
@@ -77,8 +83,8 @@ async def show_observability(plan_id: str) -> None:
         # Get event timeline
         timeline = await tracker.get_plan_timeline(
             plan_id=plan_id,
-            service_tenant_id=TENANT_ID,
-            service_user_id=USER_ID,
+            service_tenant_id=tenant_id,
+            service_user_id=user_id,
         )
         
         if timeline and timeline.events:
@@ -101,7 +107,15 @@ async def show_observability(plan_id: str) -> None:
 
 async def main() -> None:
     """Send feedback analysis goal and wait for result."""
-    client = EventClient(agent_id="feedback-client", source="feedback-client")
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
+    client = EventClient(
+        agent_id="feedback-client",
+        source="feedback-client",
+        auth_token_provider=token_provider,
+    )
     
     response_event = asyncio.Event()
     response_payload = {}
@@ -128,8 +142,8 @@ async def main() -> None:
         response_topic=EventTopic.ACTION_RESULTS,
         correlation_id=correlation_id,
         data={"product": "Soorma Hub", "sample_size": 3},
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
 
     print("[client] Waiting for response (timeout: 30s)...")
@@ -141,7 +155,7 @@ async def main() -> None:
         print(response_payload.get("result", response_payload))
         
         # Show observability data on success
-        await show_observability(plan_id)
+        await show_observability(plan_id, token_provider, tenant_id, user_id)
         
     except asyncio.TimeoutError:
         print("\n⚠️  Timeout waiting for response")
@@ -149,7 +163,7 @@ async def main() -> None:
         print("   Run: ./start.sh")
         
         # Show observability data on timeout (helps debug!)
-        await show_observability(plan_id)
+        await show_observability(plan_id, token_provider, tenant_id, user_id)
         
     finally:
         await client.disconnect()

--- a/examples/10-choreography-basic/fetcher.py
+++ b/examples/10-choreography-basic/fetcher.py
@@ -6,13 +6,25 @@ Simulates loading customer feedback from a datastore.
 
 import asyncio
 import logging
+import sys
+from pathlib import Path
 from typing import Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 
 from events import DATA_FETCH_REQUESTED_EVENT, DATA_FETCH_RESPONDED_EVENT
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "10-choreography-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 worker = Worker(
@@ -21,6 +33,7 @@ worker = Worker(
     capabilities=["feedback_fetch"],
     events_consumed=[DATA_FETCH_REQUESTED_EVENT],
     events_produced=[DATA_FETCH_RESPONDED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/10-choreography-basic/planner.py
+++ b/examples/10-choreography-basic/planner.py
@@ -10,8 +10,14 @@ bus.request() for request/response choreography. No manual intervention needed.
 """
 
 import logging
+import sys
+from pathlib import Path
 from typing import Optional
 from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma.ai.choreography import ChoreographyPlanner
 from soorma.agents.planner import GoalContext
@@ -19,6 +25,12 @@ from soorma.context import PlatformContext
 from soorma.plan_context import PlanContext
 from soorma_common.decisions import PlanAction, PlannerDecision
 from soorma_common.events import EventEnvelope
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "10-choreography-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 planner = ChoreographyPlanner(
@@ -43,6 +55,7 @@ planner = ChoreographyPlanner(
         "- Use correlation_id to maintain task tracking across the pipeline\n"
         "- Only use events that exist in the available events list"
     ),
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/10-choreography-basic/reporter.py
+++ b/examples/10-choreography-basic/reporter.py
@@ -5,13 +5,25 @@ Generates a concise report from analysis results.
 """
 
 import logging
+import sys
+from pathlib import Path
 from typing import Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 
 from events import REPORT_REQUESTED_EVENT, REPORT_RESPONDED_EVENT
+
+from examples.shared.auth import build_example_token_provider
+
+
+EXAMPLE_NAME = "10-choreography-basic"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 
 worker = Worker(
@@ -20,6 +32,7 @@ worker = Worker(
     capabilities=["feedback_reporting"],
     events_consumed=[REPORT_REQUESTED_EVENT],
     events_produced=[REPORT_RESPONDED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/10-choreography-basic/start.sh
+++ b/examples/10-choreography-basic/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="10-choreography-basic"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -31,6 +32,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 trap 'echo ""; echo "Stopping all agents..."; kill $(jobs -p) 2>/dev/null; exit 0' EXIT INT TERM

--- a/examples/11-discovery-llm/client.py
+++ b/examples/11-discovery-llm/client.py
@@ -25,16 +25,20 @@ Usage:
 
 import asyncio
 import sys
+from pathlib import Path
 from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from soorma import EventClient
 from soorma_common import EventDefinition
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
 
-# Authentication context — in production this comes from user auth
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "11-discovery-llm"
 
 DEFAULT_TOPIC = "Latest advances in quantum computing, 2025"
 TIMEOUT_SECONDS = 30.0
@@ -92,12 +96,17 @@ async def send_research_goal(description: str) -> None:
     Args:
         description: Natural-language research objective sent to the planner.
     """
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     client = EventClient(
         agent_id="discovery-llm-client",
         source="discovery-llm-client",
         # Register our response schema with the Registry on connect so the
         # planner can look it up when generating its response payload.
         events_consumed=[RESEARCH_COMPLETED_EVENT],
+        auth_token_provider=token_provider,
     )
 
     print("=" * 60)
@@ -142,8 +151,8 @@ async def send_research_goal(description: str) -> None:
         response_event=RESEARCH_COMPLETED_EVENT.event_name,
         response_topic=EventTopic.ACTION_RESULTS,
         response_schema_name=RESEARCH_COMPLETED_EVENT.payload_schema_name,
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
 
     print(f"[client] Goal published — waiting for response (timeout: {TIMEOUT_SECONDS}s)...")

--- a/examples/11-discovery-llm/planner.py
+++ b/examples/11-discovery-llm/planner.py
@@ -36,7 +36,13 @@ SDK patterns shown:
 import json
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -45,10 +51,15 @@ from soorma.agents.planner import GoalContext
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "11-discovery-llm"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Planner declaration
@@ -69,6 +80,7 @@ planner = ChoreographyPlanner(
         "4. DISPATCH: Publish the request and await the response\n\n"
         "Choose agents based on capability descriptions, not hardcoded names."
     ),
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/11-discovery-llm/start.sh
+++ b/examples/11-discovery-llm/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="11-discovery-llm"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -31,6 +32,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 trap 'echo ""; echo "Stopping all agents..."; kill $(jobs -p) 2>/dev/null; exit 0' EXIT INT TERM

--- a/examples/11-discovery-llm/worker.py
+++ b/examples/11-discovery-llm/worker.py
@@ -15,7 +15,13 @@ Key SDK usage:
 import asyncio
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -24,10 +30,15 @@ from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 from soorma_common import AgentCapability, EventDefinition
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "11-discovery-llm"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Event definitions
@@ -88,6 +99,7 @@ worker = Worker(
             produced_events=[RESEARCH_COMPLETED_EVENT],
         )
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/12-event-selector/billing_worker.py
+++ b/examples/12-event-selector/billing_worker.py
@@ -12,6 +12,12 @@ Key SDK usage:
 
 import logging
 import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -20,10 +26,15 @@ from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 from soorma_common import AgentCapability, EventDefinition
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "12-event-selector"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Event definitions
@@ -81,6 +92,7 @@ worker = Worker(
             produced_events=[TICKET_RESOLVED_EVENT],
         )
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/12-event-selector/client.py
+++ b/examples/12-event-selector/client.py
@@ -24,21 +24,24 @@ Usage:
 
 import asyncio
 import sys
+from pathlib import Path
 from typing import Any, Dict
 from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
-# Authentication context — mirrors the env vars used by the agents
-import os
-
-TENANT_ID = os.environ.get("TENANT_ID", "00000000-0000-0000-0000-000000000000")
-USER_ID = os.environ.get("USER_ID", "00000000-0000-0000-0000-000000000001")
+EXAMPLE_NAME = "12-event-selector"
 
 TIMEOUT_SECONDS = 30.0
 
@@ -92,9 +95,14 @@ async def submit_ticket(ticket_type: str) -> None:
     """
     ticket = SAMPLE_TICKETS.get(ticket_type, SAMPLE_TICKETS["technical"])
 
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
     client = EventClient(
         agent_id="ticket-client",
         source="ticket-client",
+        auth_token_provider=token_provider,
     )
 
     print("=" * 60)
@@ -162,8 +170,8 @@ async def submit_ticket(ticket_type: str) -> None:
         correlation_id=correlation_id,
         response_event="ticket.resolved",
         response_topic=EventTopic.ACTION_RESULTS,
-        tenant_id=TENANT_ID,
-        user_id=USER_ID,
+        tenant_id=tenant_id,
+        user_id=user_id,
     )
 
     try:

--- a/examples/12-event-selector/escalation_worker.py
+++ b/examples/12-event-selector/escalation_worker.py
@@ -13,6 +13,12 @@ Key SDK usage:
 
 import logging
 import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -21,10 +27,15 @@ from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 from soorma_common import AgentCapability, EventDefinition
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "12-event-selector"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Event definitions
@@ -93,6 +104,7 @@ worker = Worker(
             produced_events=[TICKET_RESOLVED_EVENT],
         )
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/12-event-selector/router.py
+++ b/examples/12-event-selector/router.py
@@ -19,7 +19,13 @@ SDK patterns shown:
 
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -30,10 +36,15 @@ from soorma.task_context import TaskContext
 from soorma_common import AgentCapability, EventDefinition
 from soorma_common.events import EventTopic
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "12-event-selector"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Event definitions
@@ -95,6 +106,7 @@ router = Worker(
             produced_events=[TICKET_ROUTED_EVENT],
         )
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/12-event-selector/start.sh
+++ b/examples/12-event-selector/start.sh
@@ -10,6 +10,7 @@ set -e
 
 EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_NAME="12-event-selector"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 
 echo "======================================================================"
 echo "  Starting Example: $EXAMPLE_NAME"
@@ -31,6 +32,10 @@ if ! curl -s http://localhost:8081/health > /dev/null 2>&1; then
 fi
 
 echo "Platform services detected"
+echo ""
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 echo ""
 
 trap 'echo ""; echo "Stopping all agents..."; kill $(jobs -p) 2>/dev/null; exit 0' EXIT INT TERM

--- a/examples/12-event-selector/technical_worker.py
+++ b/examples/12-event-selector/technical_worker.py
@@ -14,6 +14,12 @@ Key SDK usage:
 import asyncio
 import logging
 import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -22,10 +28,15 @@ from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 from soorma_common import AgentCapability, EventDefinition
 
+from examples.shared.auth import build_example_token_provider
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "12-event-selector"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Event definitions
@@ -80,6 +91,7 @@ worker = Worker(
             produced_events=[TICKET_RESOLVED_EVENT],
         )
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 

--- a/examples/13-a2a-gateway/gateway_service.py
+++ b/examples/13-a2a-gateway/gateway_service.py
@@ -21,8 +21,14 @@ SDK patterns shown:
 import asyncio
 import logging
 import os
+import sys
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 import uvicorn
 from dotenv import load_dotenv
@@ -40,6 +46,7 @@ from soorma_common.a2a import (
     A2ATaskStatus,
 )
 from soorma_common.events import EventEnvelope, EventTopic
+from examples.shared.auth import build_example_token_provider
 
 load_dotenv()
 
@@ -54,8 +61,10 @@ GATEWAY_URL: str = os.environ.get("GATEWAY_URL", "http://localhost:9000")
 GATEWAY_PORT: int = int(os.environ.get("GATEWAY_PORT", "9000"))
 EVENT_SERVICE_URL: str = os.environ.get("SOORMA_EVENT_SERVICE_URL", "http://localhost:8082")
 REGISTRY_URL: str = os.environ.get("SOORMA_REGISTRY_URL", "http://localhost:8081")
-TENANT_ID: str = os.environ.get("SOORMA_DEVELOPER_TENANT_ID", "00000000-0000-0000-0000-000000000001")
-USER_ID: str = os.environ.get("SOORMA_USER_ID", "00000000-0000-0000-0000-000000000002")
+EXAMPLE_NAME = "13-a2a-gateway"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
+TENANT_ID: Optional[str] = None
+USER_ID: Optional[str] = None
 
 # The internal event type the research agent consumes
 INTERNAL_EVENT_TYPE: str = "research.requested"
@@ -86,13 +95,17 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
     Args:
         app: The FastAPI application instance (unused; required by FastAPI API).
     """
-    global _event_client
+    global _event_client, TENANT_ID, USER_ID
+
+    await EXAMPLE_TOKEN_PROVIDER.get_token()
+    TENANT_ID = await EXAMPLE_TOKEN_PROVIDER.get_platform_tenant_id()
+    USER_ID = await EXAMPLE_TOKEN_PROVIDER.get_bootstrap_admin_principal_id()
 
     _event_client = EventClient(
         event_service_url=EVENT_SERVICE_URL,
         agent_id="a2a-gateway",
         source="a2a-gateway",
-        tenant_id=TENANT_ID,
+        auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
     )
 
     # Catch-all handler: resolve any pending Future whose correlation_id matches
@@ -152,7 +165,10 @@ async def get_agent_card() -> Dict[str, Any]:
     Raises:
         HTTPException: 503 if no agents are registered yet.
     """
-    registry = RegistryClient(base_url=REGISTRY_URL)
+    registry = RegistryClient(
+        base_url=REGISTRY_URL,
+        auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
+    )
     # No filter — discover every agent currently registered in this tenant
     agents = await registry.query_agents()
     if not agents:

--- a/examples/13-a2a-gateway/internal_agent.py
+++ b/examples/13-a2a-gateway/internal_agent.py
@@ -16,6 +16,12 @@ SDK patterns shown:
 import asyncio
 import logging
 import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dotenv import load_dotenv
 
@@ -23,11 +29,15 @@ from soorma import Worker
 from soorma.context import PlatformContext
 from soorma.task_context import TaskContext
 from soorma_common import AgentCapability, EventDefinition
+from examples.shared.auth import build_example_token_provider
 
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+EXAMPLE_NAME = "13-a2a-gateway"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # ---------------------------------------------------------------------------
 # Event definitions
@@ -98,6 +108,7 @@ worker = Worker(
             produced_events=[RESEARCH_COMPLETED_EVENT],
         )
     ],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 # ---------------------------------------------------------------------------

--- a/examples/13-a2a-gateway/start.sh
+++ b/examples/13-a2a-gateway/start.sh
@@ -6,6 +6,8 @@ set -e
 trap 'echo; echo "Shutting down..."; kill $(jobs -p) 2>/dev/null; wait 2>/dev/null' EXIT INT TERM
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXAMPLE_NAME="13-a2a-gateway"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$SCRIPT_DIR"
 
 # Activate the repo-root venv if present
@@ -13,6 +15,10 @@ if [[ -f "../../.venv/bin/activate" ]]; then
     # shellcheck disable=SC1091
     source "../../.venv/bin/activate"
 fi
+
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$SCRIPT_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 
 echo "============================================================"
 echo " Example 13 — A2A Gateway"

--- a/examples/research-advisor/advisor.py
+++ b/examples/research-advisor/advisor.py
@@ -1,5 +1,12 @@
 import asyncio
 import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
@@ -10,9 +17,10 @@ from events import (
 )
 from capabilities import ADVICE_CAPABILITY
 from llm_utils import get_llm_model, has_any_llm_key
+from examples.shared.auth import build_example_token_provider
 
-# Constants
-DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000"  # Hard-coded user ID for single-tenant mode
+EXAMPLE_NAME = "research-advisor"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # Create the Advisor Worker
 advisor = Worker(
@@ -20,7 +28,8 @@ advisor = Worker(
     description="Drafts responses based on research",
     capabilities=[ADVICE_CAPABILITY],
     events_consumed=[ADVICE_REQUEST_EVENT],
-    events_produced=[ADVICE_RESULT_EVENT]
+    events_produced=[ADVICE_RESULT_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 @advisor.on_startup
@@ -52,7 +61,7 @@ async def handle_advice_request(event: EventEnvelope, context: PlatformContext):
     # Log drafting request to episodic memory
     await context.memory.log_interaction(
         agent_id="content-drafter",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="user",
         content=f"Draft request for: {user_request} (context: {research_context[:100]}...)",
         metadata={"event_id": event.id, "has_critique": bool(critique)}
@@ -95,7 +104,7 @@ async def handle_advice_request(event: EventEnvelope, context: PlatformContext):
     # Log drafted content to episodic memory
     await context.memory.log_interaction(
         agent_id="content-drafter",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="assistant",
         content=f"Draft created: {draft_text[:200]}...",
         metadata={"event_id": event.id, "draft_length": len(draft_text)}

--- a/examples/research-advisor/client.py
+++ b/examples/research-advisor/client.py
@@ -1,13 +1,18 @@
 import asyncio
 import sys
 import uuid
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import EventClient
 from soorma_common.events import EventEnvelope, EventTopic
 from events import GOAL_EVENT, FULFILLED_EVENT
+from examples.shared.auth import build_example_token_provider
 
-
-TENANT_ID = "00000000-0000-0000-0000-000000000000"
-USER_ID = "00000000-0000-0000-0000-000000000001"
+EXAMPLE_NAME = "research-advisor"
 
 async def interactive_cli():
     """Run an interactive CLI for the Generic Agent System."""
@@ -20,7 +25,16 @@ async def interactive_cli():
     print("   (All interactions in this session share the same plan for context continuity)")
     print("   (Restart the client to begin a new plan)\n")
     
-    client = EventClient(agent_id="client", source="client")
+    token_provider = build_example_token_provider(EXAMPLE_NAME, __file__)
+    await token_provider.get_token()
+    tenant_id = await token_provider.get_platform_tenant_id()
+    user_id = await token_provider.get_bootstrap_admin_principal_id()
+
+    client = EventClient(
+        agent_id="client",
+        source="client",
+        auth_token_provider=token_provider,
+    )
     
     # Shared event to signal completion of a request
     request_completed = asyncio.Event()
@@ -70,8 +84,8 @@ async def interactive_cli():
                 event_type=GOAL_EVENT.event_name,
                 topic=GOAL_EVENT.topic,
                 data=query,
-                tenant_id=TENANT_ID,
-                user_id=USER_ID,
+                tenant_id=tenant_id,
+                user_id=user_id,
             )
             
             print("   Waiting for result...")

--- a/examples/research-advisor/planner.py
+++ b/examples/research-advisor/planner.py
@@ -1,12 +1,20 @@
 import asyncio
 import json
 import os
+import sys
+from pathlib import Path
 from typing import Dict, Any, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Planner
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
 from litellm import completion
 from llm_utils import get_llm_model
+from examples.shared.auth import build_example_token_provider
 
 from events import (
     GOAL_EVENT, FULFILLED_EVENT,
@@ -17,8 +25,8 @@ from events import (
     DraftResultPayload, ValidationResultPayload
 )
 
-# Constants
-DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000"  # Hard-coded user ID for single-tenant mode
+EXAMPLE_NAME = "research-advisor"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 """
 Memory Usage Pattern in Planner:
@@ -46,7 +54,8 @@ planner = Planner(
     description="Orchestrates workflows using autonomous LLM reasoning over discovered events",
     capabilities=["orchestration"],
     events_consumed=[GOAL_EVENT],
-    events_produced=[FULFILLED_EVENT]
+    events_produced=[FULFILLED_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 @planner.on_startup
@@ -174,6 +183,8 @@ async def execute_decision(decision: dict, available_events: list, context: Plat
     """Execute the LLM's decision - either publish an event or complete the workflow."""
     action = decision.get("action")
     reasoning = decision.get("reasoning", "No reasoning provided")
+    workflow_state = await context.memory.retrieve("workflow_state", plan_id=plan_id) or {}
+    current_user_id = workflow_state.get("user_id")
     
     print(f"   🤖 LLM Decision: {action}")
     print(f"   🤖 Reasoning: {reasoning}")
@@ -181,7 +192,7 @@ async def execute_decision(decision: dict, available_events: list, context: Plat
     # Log decision to episodic memory
     await context.memory.log_interaction(
         agent_id="agent-orchestrator",
-        user_id=DEFAULT_USER_ID,
+        user_id=current_user_id,
         role="assistant",
         content=f"Decision: {action}. Reasoning: {reasoning}",
         metadata={"plan_id": plan_id, "action": action}
@@ -196,7 +207,6 @@ async def execute_decision(decision: dict, available_events: list, context: Plat
         payload['plan_id'] = plan_id
         
         # Track action in working memory
-        workflow_state = await context.memory.retrieve("workflow_state", plan_id=plan_id) or {}
         action_history = workflow_state.get('action_history', [])
         action_history.append(event_name)
         workflow_state['action_history'] = action_history
@@ -245,7 +255,7 @@ async def execute_decision(decision: dict, available_events: list, context: Plat
         # Log completion to episodic memory
         await context.memory.log_interaction(
             agent_id="agent-orchestrator",
-            user_id=DEFAULT_USER_ID,
+            user_id=current_user_id,
             role="assistant",
             content=f"Workflow completed. Result: {result[:200]}...",
             metadata={"plan_id": plan_id, "status": "completed"}
@@ -310,7 +320,7 @@ async def handle_goal(event: EventEnvelope, context: PlatformContext):
     # Log goal to episodic memory
     await context.memory.log_interaction(
         agent_id="agent-orchestrator",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="user",
         content=data.get('goal', 'Unknown goal'),
         metadata={"plan_id": plan_id, "event_type": "goal"}
@@ -347,6 +357,7 @@ async def handle_goal(event: EventEnvelope, context: PlatformContext):
     
     # Store the current goal
     workflow_state['current_goal'] = data.get('goal')
+    workflow_state['user_id'] = event.user_id
     await context.memory.store("workflow_state", workflow_state, plan_id=plan_id)
     
     # Build trigger context based on whether this is a continuation
@@ -445,7 +456,7 @@ async def handle_validation_result(event: EventEnvelope, context: PlatformContex
     # Log validation result to episodic memory
     await context.memory.log_interaction(
         agent_id="agent-orchestrator",
-        user_id=DEFAULT_USER_ID,
+        user_id=workflow_state.get("user_id"),
         role="system",
         content=f"Validation {'PASSED' if is_valid else 'FAILED'}. Critique: {critique}",
         metadata={"plan_id": plan_id, "is_valid": is_valid}

--- a/examples/research-advisor/researcher.py
+++ b/examples/research-advisor/researcher.py
@@ -1,5 +1,12 @@
 import asyncio
 import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
@@ -11,9 +18,10 @@ from events import (
 )
 from capabilities import RESEARCH_CAPABILITY
 from llm_utils import get_llm_model, has_any_llm_key
+from examples.shared.auth import build_example_token_provider
 
-# Constants
-DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000"  # Hard-coded user ID for single-tenant mode
+EXAMPLE_NAME = "research-advisor"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 """
 Memory Usage Pattern in Web Researcher:
@@ -48,7 +56,8 @@ researcher = Worker(
     description="Performs web research on any topic",
     capabilities=[RESEARCH_CAPABILITY],
     events_consumed=[RESEARCH_REQUEST_EVENT],
-    events_produced=[RESEARCH_RESULT_EVENT]
+    events_produced=[RESEARCH_RESULT_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 @researcher.on_startup
@@ -79,7 +88,7 @@ async def handle_research_request(event: EventEnvelope, context: PlatformContext
     # Log research request to episodic memory
     await context.memory.log_interaction(
         agent_id="web-researcher",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="user",
         content=f"Research request: {query_topic} (context: {extra_context})",
         metadata={"event_id": event.id}
@@ -192,7 +201,7 @@ async def handle_research_request(event: EventEnvelope, context: PlatformContext
     #    Shows "what did the researcher do" in conversation history
     await context.memory.log_interaction(
         agent_id="web-researcher",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="assistant",
         content=f"Research completed for '{query_topic}': {summary[:200]}...",
         metadata={"event_id": event.id, "source_url": source_url}

--- a/examples/research-advisor/start.sh
+++ b/examples/research-advisor/start.sh
@@ -1,25 +1,34 @@
 #!/bin/bash
 
+set -e
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_NAME="research-advisor"
+REPO_ROOT="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+
 # Kill all background jobs on exit
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 echo "🚀 Starting Research Advisor Swarm..."
 echo "Press Ctrl+C to stop all agents."
+echo "🔐 Priming shared example token provider..."
+(cd "$REPO_ROOT" && python -m examples.shared.auth "$EXAMPLE_NAME" "$EXAMPLE_DIR") > /dev/null
+echo "✓ Example identity bootstrap and token cache ready"
 
 # 1. Start Agents in background
-python researcher.py &
+python "$EXAMPLE_DIR/researcher.py" &
 PID1=$!
 echo " - Researcher started ($PID1)"
 
-python advisor.py &
+python "$EXAMPLE_DIR/advisor.py" &
 PID2=$!
 echo " - Advisor started ($PID2)"
 
-python validator.py &
+python "$EXAMPLE_DIR/validator.py" &
 PID3=$!
 echo " - Validator started ($PID3)"
 
-python planner.py &
+python "$EXAMPLE_DIR/planner.py" &
 PID4=$!
 echo " - Planner started ($PID4)"
 
@@ -28,4 +37,4 @@ sleep 3
 
 # 2. Run the Client (Interactive)
 echo "✅ Swarm ready. Starting Client..."
-python client.py
+python "$EXAMPLE_DIR/client.py"

--- a/examples/research-advisor/validator.py
+++ b/examples/research-advisor/validator.py
@@ -1,6 +1,13 @@
 import asyncio
 import os
 import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from soorma import Worker
 from soorma.context import PlatformContext
 from soorma_common.events import EventEnvelope, EventTopic
@@ -12,9 +19,10 @@ from events import (
 )
 from capabilities import VALIDATION_CAPABILITY
 from llm_utils import get_llm_model, has_any_llm_key
+from examples.shared.auth import build_example_token_provider
 
-# Constants
-DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000"  # Hard-coded user ID for single-tenant mode
+EXAMPLE_NAME = "research-advisor"
+EXAMPLE_TOKEN_PROVIDER = build_example_token_provider(EXAMPLE_NAME, __file__)
 
 # Create the Validator Worker
 validator = Worker(
@@ -22,7 +30,8 @@ validator = Worker(
     description="Validates content against source material",
     capabilities=[VALIDATION_CAPABILITY],
     events_consumed=[VALIDATION_REQUEST_EVENT],
-    events_produced=[VALIDATION_RESULT_EVENT]
+    events_produced=[VALIDATION_RESULT_EVENT],
+    auth_token_provider=EXAMPLE_TOKEN_PROVIDER,
 )
 
 @validator.on_startup
@@ -53,7 +62,7 @@ async def handle_validation_request(event: EventEnvelope, context: PlatformConte
     # Log validation request to episodic memory
     await context.memory.log_interaction(
         agent_id="fact-checker",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="user",
         content=f"Validation request - Draft: {draft_text[:100]}... Source: {source_text[:100]}...",
         metadata={"event_id": event.id}
@@ -100,7 +109,7 @@ async def handle_validation_request(event: EventEnvelope, context: PlatformConte
     status = "APPROVED" if is_valid else "REJECTED"
     await context.memory.log_interaction(
         agent_id="fact-checker",
-        user_id=DEFAULT_USER_ID,
+        user_id=event.user_id,
         role="assistant",
         content=f"Validation {status}: {critique}",
         metadata={"event_id": event.id, "is_valid": is_valid}

--- a/examples/shared/__init__.py
+++ b/examples/shared/__init__.py
@@ -1,9 +1,24 @@
 """Shared helpers for Soorma examples."""
 
-from .auth import ExampleTokenProvider, build_example_token_provider, ensure_example_auth_token
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "ExampleTokenProvider",
     "build_example_token_provider",
     "ensure_example_auth_token",
 ]
+
+
+if TYPE_CHECKING:
+    from .auth import ExampleTokenProvider, build_example_token_provider, ensure_example_auth_token
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose shared auth helpers without pre-importing the module."""
+    if name in __all__:
+        from . import auth
+
+        return getattr(auth, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/examples/shared/__init__.py
+++ b/examples/shared/__init__.py
@@ -1,0 +1,9 @@
+"""Shared helpers for Soorma examples."""
+
+from .auth import ExampleTokenProvider, build_example_token_provider, ensure_example_auth_token
+
+__all__ = [
+    "ExampleTokenProvider",
+    "build_example_token_provider",
+    "ensure_example_auth_token",
+]

--- a/examples/shared/auth.py
+++ b/examples/shared/auth.py
@@ -1,0 +1,181 @@
+"""Reusable identity bootstrap and JWT provider helpers for examples."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import jwt
+
+from soorma.identity.client import IdentityServiceClient
+from soorma_common.models import OnboardingRequest, TokenIssueRequest, TokenIssuanceType
+
+
+DEFAULT_PLATFORM_TENANT_ID = "00000000-0000-0000-0000-000000000000"
+DEFAULT_SERVICE_USER_ID = "00000000-0000-0000-0000-000000000001"
+TOKEN_REFRESH_WINDOW_SECONDS = 30
+
+
+def bootstrap_filename(example_name: str) -> str:
+    """Return the persisted bootstrap filename for an example."""
+    return f"{example_name}-identity.json"
+
+
+def _find_repo_root(start_path: Path) -> Path:
+    """Find repository root by walking parents until examples/ and sdk/ are present."""
+    resolved_path = start_path.resolve()
+    search_roots = [resolved_path, *resolved_path.parents]
+    for candidate in search_roots:
+        if (candidate / "examples").exists() and (candidate / "sdk").exists():
+            return candidate
+    raise RuntimeError("Unable to locate soorma-core repository root from example path")
+
+
+def _get_soorma_dir(start_path: Path) -> Path:
+    """Return the shared .soorma directory used by example helpers."""
+    repo_root = _find_repo_root(start_path)
+    soorma_dir = repo_root / ".soorma"
+    soorma_dir.mkdir(exist_ok=True)
+    return soorma_dir
+
+
+def bootstrap_file_path(example_name: str, start_path: Path) -> Path:
+    """Return persisted bootstrap metadata path for an example."""
+    return _get_soorma_dir(start_path) / bootstrap_filename(example_name)
+
+
+def load_bootstrap_payload(example_name: str, start_path: Path) -> dict[str, Any] | None:
+    """Load persisted bootstrap payload when available and structurally valid."""
+    bootstrap_file = bootstrap_file_path(example_name, start_path)
+    if not bootstrap_file.exists():
+        return None
+    try:
+        payload = json.loads(bootstrap_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    required_keys = {"platform_tenant_id", "bootstrap_admin_principal_id", "tenant_domain_id"}
+    if not required_keys.issubset(payload):
+        return None
+    return payload
+
+
+def persist_bootstrap_payload(example_name: str, start_path: Path, payload: dict[str, Any]) -> None:
+    """Persist example bootstrap payload for reuse across runs."""
+    bootstrap_file = bootstrap_file_path(example_name, start_path)
+    bootstrap_file.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+
+
+def _is_token_fresh(token: str) -> bool:
+    """Return whether the cached JWT remains valid beyond the refresh window."""
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+    except jwt.PyJWTError:
+        return False
+
+    exp = payload.get("exp")
+    if exp is None:
+        return True
+
+    try:
+        expires_at = int(exp)
+    except (TypeError, ValueError):
+        return False
+
+    return expires_at - TOKEN_REFRESH_WINDOW_SECONDS > int(time.time())
+
+
+class ExampleTokenProvider:
+    """Trusted-proxy style token provider for local examples."""
+
+    def __init__(self, example_name: str, start_path: Path | str):
+        self.example_name = example_name
+        self.start_path = Path(start_path).resolve()
+        self._cached_token: Optional[str] = None
+        self._bootstrap_payload: Optional[dict[str, Any]] = None
+
+    async def __call__(self) -> str:
+        """Return a cached JWT or request a new one when needed."""
+        return await self.get_token()
+
+    async def get_token(self, force_refresh: bool = False) -> str:
+        """Return a valid JWT, bootstrapping and refreshing as needed."""
+        if not force_refresh and self._cached_token and _is_token_fresh(self._cached_token):
+            self._export_environment(self._cached_token)
+            return self._cached_token
+
+        bootstrap_payload = await self._ensure_bootstrap_payload()
+        async with IdentityServiceClient() as identity_client:
+            token_response = await identity_client.issue_token(
+                TokenIssueRequest(
+                    principal_id=str(bootstrap_payload["bootstrap_admin_principal_id"]),
+                    issuance_type=TokenIssuanceType.PLATFORM,
+                ),
+                service_tenant_id=DEFAULT_PLATFORM_TENANT_ID,
+                service_user_id=DEFAULT_SERVICE_USER_ID,
+            )
+
+        self._cached_token = token_response.token
+        self._export_environment(token_response.token)
+        return token_response.token
+
+    async def _ensure_bootstrap_payload(self) -> dict[str, Any]:
+        """Load or create the persisted example principal bootstrap payload."""
+        if self._bootstrap_payload is not None:
+            return self._bootstrap_payload
+
+        persisted_payload = load_bootstrap_payload(self.example_name, self.start_path)
+        if persisted_payload is None:
+            async with IdentityServiceClient() as identity_client:
+                onboarding_response = await identity_client.onboard_tenant(
+                    OnboardingRequest(
+                        bootstrap_admin_external_ref=f"{self.example_name}-bootstrap-admin"
+                    ),
+                    service_tenant_id=DEFAULT_PLATFORM_TENANT_ID,
+                    service_user_id=DEFAULT_SERVICE_USER_ID,
+                )
+            persisted_payload = onboarding_response.model_dump()
+            persist_bootstrap_payload(self.example_name, self.start_path, persisted_payload)
+
+        self._bootstrap_payload = persisted_payload
+        return persisted_payload
+
+    def _export_environment(self, token: str) -> None:
+        """Export current example auth context for subprocess compatibility."""
+        if self._bootstrap_payload is None:
+            return
+        os.environ["SOORMA_AUTH_TOKEN"] = token
+        os.environ["SOORMA_PLATFORM_TENANT_ID"] = str(self._bootstrap_payload["platform_tenant_id"])
+        os.environ["SOORMA_DEVELOPER_TENANT_ID"] = str(self._bootstrap_payload["platform_tenant_id"])
+
+
+def build_example_token_provider(example_name: str, start_path: Path | str) -> ExampleTokenProvider:
+    """Create a reusable token provider for an example."""
+    return ExampleTokenProvider(example_name=example_name, start_path=start_path)
+
+
+async def ensure_example_auth_token(example_name: str, start_path: Path | str) -> str:
+    """Convenience helper for eagerly provisioning a valid example JWT."""
+    provider = build_example_token_provider(example_name=example_name, start_path=start_path)
+    return await provider.get_token()
+
+
+async def _main(argv: list[str]) -> int:
+    """CLI entry point for priming example bootstrap and token state."""
+    if len(argv) != 3:
+        print("Usage: python -m examples.shared.auth <example-name> <example-path>", file=sys.stderr)
+        return 2
+
+    await ensure_example_auth_token(example_name=argv[1], start_path=argv[2])
+    return 0
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    raise SystemExit(asyncio.run(_main(sys.argv)))

--- a/examples/shared/auth.py
+++ b/examples/shared/auth.py
@@ -15,7 +15,7 @@ from soorma.identity.client import IdentityServiceClient
 from soorma_common.models import OnboardingRequest, TokenIssueRequest, TokenIssuanceType
 
 
-DEFAULT_PLATFORM_TENANT_ID = "00000000-0000-0000-0000-000000000000"
+DEFAULT_BOOTSTRAP_SERVICE_TENANT_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_SERVICE_USER_ID = "00000000-0000-0000-0000-000000000001"
 TOKEN_REFRESH_WINDOW_SECONDS = 30
 
@@ -111,12 +111,13 @@ class ExampleTokenProvider:
 
         bootstrap_payload = await self._ensure_bootstrap_payload()
         async with IdentityServiceClient() as identity_client:
+            identity_client.set_platform_tenant_id(str(bootstrap_payload["platform_tenant_id"]))
             token_response = await identity_client.issue_token(
                 TokenIssueRequest(
                     principal_id=str(bootstrap_payload["bootstrap_admin_principal_id"]),
                     issuance_type=TokenIssuanceType.PLATFORM,
                 ),
-                service_tenant_id=DEFAULT_PLATFORM_TENANT_ID,
+                service_tenant_id=DEFAULT_BOOTSTRAP_SERVICE_TENANT_ID,
                 service_user_id=DEFAULT_SERVICE_USER_ID,
             )
 
@@ -136,7 +137,7 @@ class ExampleTokenProvider:
                     OnboardingRequest(
                         bootstrap_admin_external_ref=f"{self.example_name}-bootstrap-admin"
                     ),
-                    service_tenant_id=DEFAULT_PLATFORM_TENANT_ID,
+                    service_tenant_id=DEFAULT_BOOTSTRAP_SERVICE_TENANT_ID,
                     service_user_id=DEFAULT_SERVICE_USER_ID,
                 )
             persisted_payload = onboarding_response.model_dump()
@@ -152,6 +153,20 @@ class ExampleTokenProvider:
         os.environ["SOORMA_AUTH_TOKEN"] = token
         os.environ["SOORMA_PLATFORM_TENANT_ID"] = str(self._bootstrap_payload["platform_tenant_id"])
         os.environ["SOORMA_DEVELOPER_TENANT_ID"] = str(self._bootstrap_payload["platform_tenant_id"])
+
+    async def get_bootstrap_payload(self) -> dict[str, Any]:
+        """Return the persisted onboarding payload for this example."""
+        return await self._ensure_bootstrap_payload()
+
+    async def get_platform_tenant_id(self) -> str:
+        """Return the bootstrapped platform tenant ID for this example."""
+        payload = await self._ensure_bootstrap_payload()
+        return str(payload["platform_tenant_id"])
+
+    async def get_bootstrap_admin_principal_id(self) -> str:
+        """Return the bootstrapped admin principal ID for this example."""
+        payload = await self._ensure_bootstrap_payload()
+        return str(payload["bootstrap_admin_principal_id"])
 
 
 def build_example_token_provider(example_name: str, start_path: Path | str) -> ExampleTokenProvider:

--- a/libs/soorma-service-common/README.md
+++ b/libs/soorma-service-common/README.md
@@ -4,7 +4,7 @@ Shared FastAPI/Starlette infrastructure library for Soorma backend services.
 
 Provides three cross-cutting concerns for all services (Memory, Tracker, Registry, Event Service):
 
-1. **Identity extraction** — `TenancyMiddleware` reads the three identity dimensions from HTTP headers into `request.state` on every request.
+1. **Identity extraction** — `TenancyMiddleware` validates bearer tokens and projects platform-tenant, service-tenant, and service-user identity into `request.state` on secured requests.
 2. **RLS activation** — `create_get_tenanted_db` factory produces a FastAPI dependency that calls PostgreSQL `set_config` for all three session variables (transaction-scoped) before yielding the DB session, activating Row-Level Security policies.
 3. **GDPR deletion contract** — `PlatformTenantDataDeletion` abstract base class defines the erasure interface; concrete implementations live in each service.
 
@@ -42,4 +42,4 @@ async def create_item(payload: ItemCreate, ctx: TenantContext = Depends(get_tena
 ## Constraints
 
 - **MUST NOT** be imported by `soorma-common` or `sdk/python` — contains FastAPI/Starlette dependencies incompatible with SDK clients.
-- `platform_tenant_id` flows only via HTTP header (`X-Tenant-ID`) or Event Service injection — never as a per-call API parameter.
+- `platform_tenant_id` flows from validated request identity or Event Service injection — never as a per-call API parameter.

--- a/libs/soorma-service-common/src/soorma_service_common/middleware.py
+++ b/libs/soorma-service-common/src/soorma_service_common/middleware.py
@@ -1,8 +1,9 @@
-"""Tenancy middleware with JWT-first coexistence behavior.
+"""Tenancy middleware for bearer-authenticated request identity.
 
 Resolution order:
-1. If bearer JWT exists, validate and use JWT claims for request identity.
-2. If JWT is absent, fall back to legacy tenancy headers.
+1. If bearer JWT exists, validate it and project claims into request state.
+2. If a trusted identity admin header exists, allow the documented admin bypass.
+3. Otherwise fail closed with missing-bearer-token authentication errors.
 
 Middleware never calls set_config; DB session/RLS activation remains in
 dependency utilities.
@@ -71,10 +72,10 @@ def configure_platform_tenant_openapi(
     scheme_name: str = "PlatformTenantHeader",
     header_name: str = "X-Tenant-ID",
 ) -> None:
-    """Expose platform tenant header in Swagger/OpenAPI for all operations.
+    """Expose platform tenant header in Swagger/OpenAPI for compatibility flows.
 
-    This adds an API key security scheme backed by ``X-Tenant-ID`` and applies it
-    globally so Swagger UI can send the header via the Authorize dialog.
+    This helper documents ``X-Tenant-ID`` for trusted-admin or compatibility
+    scenarios. Normal secured service traffic authenticates with bearer tokens.
     """
 
     original_openapi = app.openapi

--- a/libs/soorma-service-common/src/soorma_service_common/middleware.py
+++ b/libs/soorma-service-common/src/soorma_service_common/middleware.py
@@ -24,9 +24,17 @@ from starlette.responses import Response
 
 from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 
-_BYPASS_PATHS = frozenset(["/health", "/docs", "/openapi.json", "/redoc"])
+_BYPASS_PATHS = frozenset([
+    "/health",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+    "/v1/identity/.well-known/openid-configuration",
+    "/v1/identity/.well-known/jwks.json",
+])
 _AUTHORIZATION_HEADER = "authorization"
 _BEARER_PREFIX = "bearer "
+_IDENTITY_ADMIN_HEADER = "x-identity-admin-key"
 _JWT_SECRET_ENV = "SOORMA_AUTH_JWT_SECRET"
 _JWT_ISSUER_ENV = "SOORMA_AUTH_JWT_ISSUER"
 _JWT_AUDIENCE_ENV = "SOORMA_AUTH_JWT_AUDIENCE"
@@ -38,7 +46,9 @@ _JWKS_JSON_ENV = "SOORMA_AUTH_JWKS_JSON"
 _JWKS_CACHE_TTL_ENV = "SOORMA_AUTH_JWKS_CACHE_TTL_SECONDS"
 _OPENID_CONFIGURATION_URL_ENV = "SOORMA_AUTH_OPENID_CONFIGURATION_URL"
 _OPENID_CONFIGURATION_JSON_ENV = "SOORMA_AUTH_OPENID_CONFIGURATION_JSON"
-_ALLOWED_PRINCIPAL_TYPES = frozenset({"admin", "service", "agent", "user"})
+_ALLOWED_PRINCIPAL_TYPES = frozenset(
+    {"admin", "service", "agent", "user", "developer", "planner", "worker", "tool"}
+)
 _JWKS_CACHE_TIMEOUT_SECONDS = 2.0
 _DEFAULT_JWKS_CACHE_TTL_SECONDS = 300
 
@@ -151,6 +161,10 @@ class TenancyMiddleware(BaseHTTPMiddleware):
 
     Does NOT open or interact with a database connection (BR-U2-01).
     """
+
+    def _is_identity_admin_request(self, request: Request) -> bool:
+        """Return True for trusted admin-key identity-service control-plane requests."""
+        return bool(str(request.headers.get(_IDENTITY_ADMIN_HEADER) or "").strip())
 
     def _extract_bearer_token(self, request: Request) -> str | None:
         """Extract bearer token from Authorization header when present."""
@@ -379,7 +393,9 @@ class TenancyMiddleware(BaseHTTPMiddleware):
         else:
             raise HTTPException(status_code=401, detail="Invalid JWT")
 
-        platform_tenant_id = str(claims.get("platform_tenant_id") or "").strip()
+        platform_tenant_id = str(
+            claims.get("tenant_id") or claims.get("platform_tenant_id") or ""
+        ).strip()
         if not platform_tenant_id:
             raise HTTPException(status_code=401, detail="Invalid JWT")
 
@@ -461,7 +477,7 @@ class TenancyMiddleware(BaseHTTPMiddleware):
                 request.state.auth_source = "jwt"
             except HTTPException as exc:
                 return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
-        else:
+        elif self._is_identity_admin_request(request):
             request.state.platform_tenant_id = (
                 request.headers.get("x-tenant-id") or DEFAULT_PLATFORM_TENANT_ID
             )
@@ -472,6 +488,8 @@ class TenancyMiddleware(BaseHTTPMiddleware):
             request.state.roles = []
             request.state.auth_issuer = None
             request.state.auth_audience = None
-            request.state.auth_source = "legacy-header"
+            request.state.auth_source = "trusted-admin-header"
+        else:
+            return JSONResponse(status_code=401, content={"detail": "Missing bearer token"})
 
         return await call_next(request)

--- a/libs/soorma-service-common/src/soorma_service_common/middleware.py
+++ b/libs/soorma-service-common/src/soorma_service_common/middleware.py
@@ -399,8 +399,17 @@ class TenancyMiddleware(BaseHTTPMiddleware):
         if not platform_tenant_id:
             raise HTTPException(status_code=401, detail="Invalid JWT")
 
-        service_tenant = claims.get("service_tenant_id")
-        service_user = claims.get("service_user_id")
+        service_tenant = (
+            claims.get("service_tenant_id")
+            or claims.get("tenant_id")
+            or claims.get("platform_tenant_id")
+        )
+        service_user = (
+            claims.get("service_user_id")
+            or claims.get("user_id")
+            or claims.get("principal_id")
+            or claims.get("sub")
+        )
         service_tenant_id = str(service_tenant).strip() if service_tenant is not None else None
         service_user_id = str(service_user).strip() if service_user is not None else None
 

--- a/libs/soorma-service-common/tests/test_middleware.py
+++ b/libs/soorma-service-common/tests/test_middleware.py
@@ -179,6 +179,41 @@ class TestTenancyMiddlewareJwtCoexistence:
         assert response.json()["service_tenant_id"] == "tenant_jwt"
         assert response.json()["service_user_id"] == "user_jwt"
 
+    def test_jwt_without_service_aliases_uses_canonical_claim_fallback(self, make_test_app, monkeypatch):
+        """Canonical tenant_id and principal_id claims should populate service identity."""
+        import jwt
+
+        monkeypatch.setenv("SOORMA_AUTH_JWT_SECRET", "test-secret")
+        monkeypatch.setenv("SOORMA_AUTH_JWT_ISSUER", "soorma-identity")
+        monkeypatch.setenv("SOORMA_AUTH_JWT_AUDIENCE", "soorma-services")
+
+        token = jwt.encode(
+            {
+                "tenant_id": "tenant_canonical",
+                "platform_tenant_id": "spt_jwt",
+                "principal_id": "principal-123",
+                "sub": "subject-456",
+                "exp": 4102444800,
+                "aud": "soorma-services",
+                "iss": "soorma-identity",
+            },
+            "test-secret",
+            algorithm="HS256",
+        )
+
+        client = TestClient(make_test_app(), raise_server_exceptions=False)
+        response = client.get(
+            "/test",
+            headers={
+                "Authorization": f"Bearer {token}",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["platform_tenant_id"] == "tenant_canonical"
+        assert response.json()["service_tenant_id"] == "tenant_canonical"
+        assert response.json()["service_user_id"] == "principal-123"
+
     def test_jwt_with_mismatching_alias_headers_fails_closed(self, make_test_app, monkeypatch):
         """When JWT and alias headers disagree, middleware denies fail-closed."""
         import jwt

--- a/libs/soorma-service-common/tests/test_middleware.py
+++ b/libs/soorma-service-common/tests/test_middleware.py
@@ -43,55 +43,61 @@ def _build_jwks_json(kid: str, public_pem: str) -> str:
 
 
 class TestTenancyMiddlewareHeaderExtraction:
-    """TenancyMiddleware extracts identity headers into request.state."""
+    """TenancyMiddleware extracts identity headers for trusted admin-key requests."""
+
+    @staticmethod
+    def _admin_headers(**extra_headers: str) -> dict[str, str]:
+        headers = {"X-Identity-Admin-Key": "dev-identity-admin"}
+        headers.update(extra_headers)
+        return headers
 
     def test_x_tenant_id_populates_platform_tenant_id(self, make_test_app):
-        """X-Tenant-ID header → request.state.platform_tenant_id."""
+        """Trusted admin request projects X-Tenant-ID into request.state.platform_tenant_id."""
         client = TestClient(make_test_app(), raise_server_exceptions=False)
-        response = client.get("/test", headers={"X-Tenant-ID": "spt_acme"})
+        response = client.get("/test", headers=self._admin_headers(**{"X-Tenant-ID": "spt_acme"}))
         assert response.status_code == 200
         assert response.json()["platform_tenant_id"] == "spt_acme"
 
     def test_missing_x_tenant_id_uses_default(self, make_test_app):
-        """Absent X-Tenant-ID → request.state.platform_tenant_id = DEFAULT_PLATFORM_TENANT_ID."""
+        """Trusted admin request without X-Tenant-ID uses DEFAULT_PLATFORM_TENANT_ID."""
         from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 
         client = TestClient(make_test_app(), raise_server_exceptions=False)
-        response = client.get("/test")
+        response = client.get("/test", headers=self._admin_headers())
         assert response.status_code == 200
         assert response.json()["platform_tenant_id"] == DEFAULT_PLATFORM_TENANT_ID
 
     def test_x_service_tenant_id_populates_service_tenant_id(self, make_test_app):
-        """X-Service-Tenant-ID header → request.state.service_tenant_id."""
+        """Trusted admin request projects X-Service-Tenant-ID into request.state.service_tenant_id."""
         client = TestClient(make_test_app(), raise_server_exceptions=False)
         response = client.get(
             "/test",
-            headers={"X-Tenant-ID": "spt_acme", "X-Service-Tenant-ID": "tenant-org-1"},
+            headers=self._admin_headers(**{"X-Tenant-ID": "spt_acme", "X-Service-Tenant-ID": "tenant-org-1"}),
         )
         assert response.status_code == 200
         assert response.json()["service_tenant_id"] == "tenant-org-1"
 
     def test_missing_x_service_tenant_id_is_none(self, make_test_app):
-        """Absent X-Service-Tenant-ID → request.state.service_tenant_id is None."""
+        """Trusted admin request without X-Service-Tenant-ID leaves request.state.service_tenant_id as None."""
         client = TestClient(make_test_app(), raise_server_exceptions=False)
-        response = client.get("/test", headers={"X-Tenant-ID": "spt_acme"})
+        response = client.get("/test", headers=self._admin_headers(**{"X-Tenant-ID": "spt_acme"}))
         assert response.status_code == 200
         assert response.json()["service_tenant_id"] is None
 
     def test_x_user_id_populates_service_user_id(self, make_test_app):
-        """X-User-ID header → request.state.service_user_id."""
+        """Trusted admin request projects X-User-ID into request.state.service_user_id."""
         client = TestClient(make_test_app(), raise_server_exceptions=False)
         response = client.get(
             "/test",
-            headers={"X-Tenant-ID": "spt_acme", "X-User-ID": "user-42"},
+            headers=self._admin_headers(**{"X-Tenant-ID": "spt_acme", "X-User-ID": "user-42"}),
         )
         assert response.status_code == 200
         assert response.json()["service_user_id"] == "user-42"
 
     def test_missing_x_user_id_is_none(self, make_test_app):
-        """Absent X-User-ID → request.state.service_user_id is None."""
+        """Trusted admin request without X-User-ID leaves request.state.service_user_id as None."""
         client = TestClient(make_test_app(), raise_server_exceptions=False)
-        response = client.get("/test", headers={"X-Tenant-ID": "spt_acme"})
+        response = client.get("/test", headers=self._admin_headers(**{"X-Tenant-ID": "spt_acme"}))
         assert response.status_code == 200
         assert response.json()["service_user_id"] is None
 
@@ -224,8 +230,8 @@ class TestTenancyMiddlewareJwtCoexistence:
         )
         assert response.status_code == 401
 
-    def test_no_jwt_uses_legacy_headers(self, make_test_app):
-        """If JWT is absent, middleware must continue legacy header path."""
+    def test_no_jwt_without_admin_bypass_is_denied(self, make_test_app):
+        """If JWT is absent and no trusted admin bypass exists, middleware denies access."""
         client = TestClient(make_test_app(), raise_server_exceptions=False)
         response = client.get(
             "/test",
@@ -235,10 +241,55 @@ class TestTenancyMiddlewareJwtCoexistence:
                 "X-User-ID": "user_header",
             },
         )
+        assert response.status_code == 401
+
+    def test_admin_header_bypass_allows_identity_control_plane_request(self, make_test_app):
+        """Trusted admin-key requests may bypass JWT enforcement for identity control-plane routes."""
+        client = TestClient(make_test_app(), raise_server_exceptions=False)
+        response = client.get(
+            "/test",
+            headers={
+                "X-Tenant-ID": "spt_header",
+                "X-Service-Tenant-ID": "tenant_header",
+                "X-User-ID": "user_header",
+                "X-Identity-Admin-Key": "dev-identity-admin",
+            },
+        )
         assert response.status_code == 200
         assert response.json()["platform_tenant_id"] == "spt_header"
         assert response.json()["service_tenant_id"] == "tenant_header"
         assert response.json()["service_user_id"] == "user_header"
+
+    def test_jwt_uses_canonical_tenant_id_claim_when_present(self, make_test_app, monkeypatch):
+        """Middleware should prefer canonical tenant_id claim over legacy platform_tenant_id claim."""
+        import jwt
+
+        monkeypatch.setenv("SOORMA_AUTH_JWT_SECRET", "test-secret")
+        monkeypatch.setenv("SOORMA_AUTH_JWT_ISSUER", "soorma-identity")
+        monkeypatch.setenv("SOORMA_AUTH_JWT_AUDIENCE", "soorma-services")
+
+        token = jwt.encode(
+            {
+                "tenant_id": "tenant-canonical",
+                "platform_tenant_id": "tenant-legacy",
+                "service_tenant_id": "svc-tenant",
+                "service_user_id": "svc-user",
+                "exp": 4102444800,
+                "aud": "soorma-services",
+                "iss": "soorma-identity",
+            },
+            "test-secret",
+            algorithm="HS256",
+        )
+
+        client = TestClient(make_test_app(), raise_server_exceptions=False)
+        response = client.get(
+            "/test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["platform_tenant_id"] == "tenant-canonical"
 
     def test_jwt_invalid_principal_type_fails_closed(self, make_test_app, monkeypatch):
         """JWT with unsupported principal_type must fail closed (401)."""

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `soorma dev` now generates a local RSA keypair on first bootstrap, persists it under `.soorma/identity/`, reuses it across runs, and derives inline JWKS/public-key verifier material from those persisted files instead of shipping a hardcoded dev private key.
+- Memory and Tracker low-level clients now project bearer auth without legacy `X-*` identity headers on the active JWT path.
+
 ## [0.8.2] - 2026-03-14
 
 ### Changed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -25,6 +25,7 @@ rich = ">=10.11.0"
 httpx = ">=0.26.0"  # For EventClient SSE streaming
 soorma-common = ">=0.8.0"
 pyjwt = ">=2.8.0"  # Required by identity client (import jwt)
+cryptography = ">=42.0.0"  # Required for local RS256 key generation in soorma dev
 litellm = {version = "^1.36", optional = true}  # For ChoreographyPlanner LLM integration
 
 [tool.poetry.extras]

--- a/sdk/python/soorma/agents/base.py
+++ b/sdk/python/soorma/agents/base.py
@@ -39,7 +39,7 @@ from uuid import uuid4
 
 from soorma_common.events import EventEnvelope, EventTopic
 
-from ..auth import AuthTokenProvider
+from ..auth import AuthTokenProvider, build_optional_auth_kwargs
 from ..context import PlatformContext
 from ..events import EventClient
 
@@ -399,8 +399,7 @@ class Agent(ABC):
             event_service_url=self.config.event_service_url,
             agent_id=self.agent_id,
             source=self.name,
-            auth_token=auth_token,
-            auth_token_provider=auth_token_provider,
+            **build_optional_auth_kwargs(auth_token, auth_token_provider),
         )
         
         # Register our event handlers with the EventClient
@@ -468,19 +467,16 @@ class Agent(ABC):
         self._context = PlatformContext(
             registry=RegistryClient(
                 base_url=self.config.registry_url,
-                auth_token=auth_token,
-                auth_token_provider=auth_token_provider,
+                **build_optional_auth_kwargs(auth_token, auth_token_provider),
             ),
             memory=MemoryClient(
                 base_url=self.config.memory_url,
-                auth_token=auth_token,
-                auth_token_provider=auth_token_provider,
+                **build_optional_auth_kwargs(auth_token, auth_token_provider),
             ),
             bus=BusClient(event_client=event_client),
             tracker=TrackerClient(
                 base_url=self.config.tracker_url,
-                auth_token=auth_token,
-                auth_token_provider=auth_token_provider,
+                **build_optional_auth_kwargs(auth_token, auth_token_provider),
             ),
             auth_token=auth_token,
             auth_token_provider=auth_token_provider,

--- a/sdk/python/soorma/agents/base.py
+++ b/sdk/python/soorma/agents/base.py
@@ -39,6 +39,7 @@ from uuid import uuid4
 
 from soorma_common.events import EventEnvelope, EventTopic
 
+from ..auth import AuthTokenProvider
 from ..context import PlatformContext
 from ..events import EventClient
 
@@ -133,6 +134,8 @@ class Agent(ABC):
         events_produced: Optional[List[Any]] = None,
         agent_id: Optional[str] = None,
         auto_register: bool = True,
+        auth_token: Optional[str] = None,
+        auth_token_provider: Optional[AuthTokenProvider] = None,
     ):
         """
         Initialize the agent.
@@ -147,6 +150,8 @@ class Agent(ABC):
             events_produced: Event types this agent publishes (strings or EventDefinition objects)
             agent_id: Unique ID (auto-generated if not provided)
             auto_register: Whether to register with Registry on startup
+            auth_token: Optional bearer token for downstream service calls
+            auth_token_provider: Optional async token provider for downstream service calls
         """
         # Process events to separate strings and definitions
         consumed_strings = []
@@ -207,6 +212,8 @@ class Agent(ABC):
         self.description = description
         self.version = version
         self.capabilities = self.config.capabilities
+        self._auth_token = auth_token
+        self._auth_token_provider = auth_token_provider
         
         # Platform context (initialized on run)
         self._context: Optional[PlatformContext] = None
@@ -384,12 +391,16 @@ class Agent(ABC):
     async def _initialize_context(self) -> None:
         """Initialize the platform context."""
         logger.info(f"Initializing platform context for {self.name}")
+        auth_token = self._auth_token if self._auth_token is not None else os.getenv("SOORMA_AUTH_TOKEN")
+        auth_token_provider = self._auth_token_provider
         
         # Create EventClient for bus
         event_client = EventClient(
             event_service_url=self.config.event_service_url,
             agent_id=self.agent_id,
             source=self.name,
+            auth_token=auth_token,
+            auth_token_provider=auth_token_provider,
         )
         
         # Register our event handlers with the EventClient
@@ -457,10 +468,22 @@ class Agent(ABC):
         self._context = PlatformContext(
             registry=RegistryClient(
                 base_url=self.config.registry_url,
+                auth_token=auth_token,
+                auth_token_provider=auth_token_provider,
             ),
-            memory=MemoryClient(base_url=self.config.memory_url),
+            memory=MemoryClient(
+                base_url=self.config.memory_url,
+                auth_token=auth_token,
+                auth_token_provider=auth_token_provider,
+            ),
             bus=BusClient(event_client=event_client),
-            tracker=TrackerClient(base_url=self.config.tracker_url),
+            tracker=TrackerClient(
+                base_url=self.config.tracker_url,
+                auth_token=auth_token,
+                auth_token_provider=auth_token_provider,
+            ),
+            auth_token=auth_token,
+            auth_token_provider=auth_token_provider,
         )
     
     async def _register_with_registry(self) -> bool:

--- a/sdk/python/soorma/agents/base.py
+++ b/sdk/python/soorma/agents/base.py
@@ -391,7 +391,7 @@ class Agent(ABC):
     async def _initialize_context(self) -> None:
         """Initialize the platform context."""
         logger.info(f"Initializing platform context for {self.name}")
-        auth_token = self._auth_token if self._auth_token is not None else os.getenv("SOORMA_AUTH_TOKEN")
+        auth_token = self._auth_token
         auth_token_provider = self._auth_token_provider
         
         # Create EventClient for bus

--- a/sdk/python/soorma/auth.py
+++ b/sdk/python/soorma/auth.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Awaitable, Callable, Optional, TypeAlias
+from typing import Any, Awaitable, Callable, Optional, TypeAlias
 
 
 AuthTokenProvider: TypeAlias = Callable[[], str | None | Awaitable[str | None]]
@@ -23,3 +23,16 @@ async def resolve_auth_token(
 
     token = str(resolved or "").strip()
     return token or None
+
+
+def build_optional_auth_kwargs(
+    auth_token: Optional[str],
+    auth_token_provider: Optional[AuthTokenProvider],
+) -> dict[str, Any]:
+    """Return only explicitly configured auth kwargs for client constructors."""
+    kwargs: dict[str, Any] = {}
+    if auth_token is not None:
+        kwargs["auth_token"] = auth_token
+    if auth_token_provider is not None:
+        kwargs["auth_token_provider"] = auth_token_provider
+    return kwargs

--- a/sdk/python/soorma/auth.py
+++ b/sdk/python/soorma/auth.py
@@ -1,0 +1,25 @@
+"""Shared auth-token provider primitives for SDK clients."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Awaitable, Callable, Optional, TypeAlias
+
+
+AuthTokenProvider: TypeAlias = Callable[[], str | None | Awaitable[str | None]]
+
+
+async def resolve_auth_token(
+    auth_token: Optional[str],
+    auth_token_provider: Optional[AuthTokenProvider],
+) -> Optional[str]:
+    """Resolve a bearer token from explicit value or provider."""
+    if auth_token_provider is None:
+        resolved = auth_token
+    else:
+        resolved = auth_token_provider()
+        if inspect.isawaitable(resolved):
+            resolved = await resolved
+
+    token = str(resolved or "").strip()
+    return token or None

--- a/sdk/python/soorma/cli/commands/dev.py
+++ b/sdk/python/soorma/cli/commands/dev.py
@@ -18,6 +18,23 @@ from pathlib import Path
 from typing import Optional, List
 
 import typer
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+    load_pem_private_key,
+    load_pem_public_key,
+)
+from jwt.algorithms import RSAAlgorithm
+
+
+DEV_IDENTITY_ACTIVE_SIGNING_KID = "dev-rs256"
+DEV_IDENTITY_DIR_NAME = "identity"
+DEV_IDENTITY_PRIVATE_KEY_FILE = "identity-signing-private.pem"
+DEV_IDENTITY_PUBLIC_KEY_FILE = "identity-signing-public.pem"
+DEV_IDENTITY_JWKS_FILE = "identity-jwks.json"
 
 # Docker Compose template for local development infrastructure
 DOCKER_COMPOSE_TEMPLATE = '''# Soorma Local Development Stack
@@ -70,7 +87,8 @@ services:
             - DATABASE_URL=postgresql+asyncpg://soorma:soorma@postgres:5432/registry
             - SYNC_DATABASE_URL=postgresql+psycopg2://soorma:soorma@postgres:5432/registry
             - NATS_URL=nats://nats:4222
-            - SOORMA_AUTH_JWT_SECRET=${SOORMA_AUTH_JWT_SECRET:-dev-identity-signing-key}
+            - SOORMA_AUTH_JWKS_JSON=${SOORMA_AUTH_JWKS_JSON:-}
+            - SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON=${SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON:-}
             - SOORMA_AUTH_JWT_ISSUER=${SOORMA_AUTH_JWT_ISSUER:-soorma-identity-service}
             - SOORMA_AUTH_JWT_AUDIENCE=${SOORMA_AUTH_JWT_AUDIENCE:-soorma-services}
         depends_on:
@@ -95,7 +113,8 @@ services:
             - EVENT_ADAPTER=nats
             - NATS_URL=nats://nats:4222
             - DEBUG=false
-            - SOORMA_AUTH_JWT_SECRET=${SOORMA_AUTH_JWT_SECRET:-dev-identity-signing-key}
+            - SOORMA_AUTH_JWKS_JSON=${SOORMA_AUTH_JWKS_JSON:-}
+            - SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON=${SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON:-}
             - SOORMA_AUTH_JWT_ISSUER=${SOORMA_AUTH_JWT_ISSUER:-soorma-identity-service}
             - SOORMA_AUTH_JWT_AUDIENCE=${SOORMA_AUTH_JWT_AUDIENCE:-soorma-services}
         depends_on:
@@ -122,7 +141,8 @@ services:
             - OPENAI_API_KEY=${OPENAI_API_KEY:-}
             - IS_LOCAL_TESTING=true
             - IS_PROD=false
-            - SOORMA_AUTH_JWT_SECRET=${SOORMA_AUTH_JWT_SECRET:-dev-identity-signing-key}
+            - SOORMA_AUTH_JWKS_JSON=${SOORMA_AUTH_JWKS_JSON:-}
+            - SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON=${SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON:-}
             - SOORMA_AUTH_JWT_ISSUER=${SOORMA_AUTH_JWT_ISSUER:-soorma-identity-service}
             - SOORMA_AUTH_JWT_AUDIENCE=${SOORMA_AUTH_JWT_AUDIENCE:-soorma-services}
         depends_on:
@@ -147,7 +167,8 @@ services:
             - NATS_URL=nats://nats:4222
             - IS_LOCAL_TESTING=true
             - IS_PROD=false
-            - SOORMA_AUTH_JWT_SECRET=${SOORMA_AUTH_JWT_SECRET:-dev-identity-signing-key}
+            - SOORMA_AUTH_JWKS_JSON=${SOORMA_AUTH_JWKS_JSON:-}
+            - SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON=${SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON:-}
             - SOORMA_AUTH_JWT_ISSUER=${SOORMA_AUTH_JWT_ISSUER:-soorma-identity-service}
             - SOORMA_AUTH_JWT_AUDIENCE=${SOORMA_AUTH_JWT_AUDIENCE:-soorma-services}
         depends_on:
@@ -173,8 +194,14 @@ services:
             - SYNC_DATABASE_URL=postgresql+psycopg2://soorma:soorma@postgres:5432/identity
             - IS_PROD=false
             - IDENTITY_ADMIN_API_KEY=${IDENTITY_ADMIN_API_KEY:-dev-identity-admin}
-            - IDENTITY_SIGNING_KEY=${IDENTITY_SIGNING_KEY:-dev-identity-signing-key}
-            - SOORMA_AUTH_JWT_SECRET=${SOORMA_AUTH_JWT_SECRET:-dev-identity-signing-key}
+            - IDENTITY_SIGNING_ALGORITHM=${IDENTITY_SIGNING_ALGORITHM:-RS256}
+            - IDENTITY_ACTIVE_SIGNING_KID=${IDENTITY_ACTIVE_SIGNING_KID:-dev-rs256}
+            - IDENTITY_SIGNING_PRIVATE_KEYRING_JSON=${IDENTITY_SIGNING_PRIVATE_KEYRING_JSON:-}
+            - IDENTITY_SIGNING_PUBLIC_KEYRING_JSON=${IDENTITY_SIGNING_PUBLIC_KEYRING_JSON:-}
+            - IDENTITY_JWKS_PUBLICATION_JSON=${IDENTITY_JWKS_PUBLICATION_JSON:-}
+            - IDENTITY_VERIFIER_JWKS_JSON=${IDENTITY_VERIFIER_JWKS_JSON:-}
+            - SOORMA_AUTH_JWKS_JSON=${SOORMA_AUTH_JWKS_JSON:-}
+            - SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON=${SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON:-}
             - SOORMA_AUTH_JWT_ISSUER=${SOORMA_AUTH_JWT_ISSUER:-soorma-identity-service}
             - SOORMA_AUTH_JWT_AUDIENCE=${SOORMA_AUTH_JWT_AUDIENCE:-soorma-services}
         depends_on:
@@ -313,6 +340,134 @@ def build_bootstrap_fingerprint(config: dict[str, str]) -> str:
     """Build deterministic fingerprint for stack bootstrap configuration."""
     canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def get_dev_identity_dir(soorma_dir: Path) -> Path:
+    """Return the persisted local identity-material directory under .soorma."""
+    identity_dir = soorma_dir / DEV_IDENTITY_DIR_NAME
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    return identity_dir
+
+
+def _build_dev_identity_jwks_payload(active_signing_kid: str, public_key_pem: str) -> dict[str, list[dict[str, object]]]:
+    """Build JWKS publication payload for the persisted local public key."""
+    public_key = load_pem_public_key(public_key_pem.encode("utf-8"))
+    jwk_payload = json.loads(RSAAlgorithm.to_jwk(public_key))
+    jwk_payload.update({"kid": active_signing_kid, "use": "sig", "alg": "RS256"})
+    return {"keys": [jwk_payload]}
+
+
+def _write_text_if_changed(path: Path, content: str) -> None:
+    """Write text only when the persisted content differs."""
+    if path.exists() and path.read_text() == content:
+        return
+    path.write_text(content)
+
+
+def load_or_create_dev_identity_material(soorma_dir: Path, active_signing_kid: str) -> dict[str, str]:
+    """Load persisted dev identity keys from .soorma or generate them on first use."""
+    identity_dir = get_dev_identity_dir(soorma_dir)
+    private_key_path = identity_dir / DEV_IDENTITY_PRIVATE_KEY_FILE
+    public_key_path = identity_dir / DEV_IDENTITY_PUBLIC_KEY_FILE
+    jwks_path = identity_dir / DEV_IDENTITY_JWKS_FILE
+
+    private_key_pem: str
+    public_key_pem: str
+    should_generate = not (private_key_path.exists() and public_key_path.exists())
+
+    if not should_generate:
+        try:
+            private_key_pem = private_key_path.read_text()
+            public_key_pem = public_key_path.read_text()
+            load_pem_private_key(private_key_pem.encode("utf-8"), password=None)
+            load_pem_public_key(public_key_pem.encode("utf-8"))
+        except (OSError, ValueError, TypeError):
+            should_generate = True
+
+    if should_generate:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        private_key_pem = private_key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.PKCS8,
+            encryption_algorithm=NoEncryption(),
+        ).decode("utf-8")
+        public_key_pem = private_key.public_key().public_bytes(
+            encoding=Encoding.PEM,
+            format=PublicFormat.SubjectPublicKeyInfo,
+        ).decode("utf-8")
+        private_key_path.write_text(private_key_pem)
+        public_key_path.write_text(public_key_pem)
+
+    jwks_publication_json = json.dumps(
+        _build_dev_identity_jwks_payload(active_signing_kid, public_key_pem)
+    )
+    _write_text_if_changed(jwks_path, jwks_publication_json)
+
+    return {
+        "identity_signing_private_keyring_json": json.dumps({active_signing_kid: private_key_pem}),
+        "identity_signing_public_keyring_json": json.dumps({active_signing_kid: public_key_pem}),
+        "identity_jwks_publication_json": jwks_publication_json,
+    }
+
+
+def resolve_dev_identity_bootstrap_config(soorma_dir: Path | None = None) -> dict[str, str]:
+    """Resolve deterministic RS256/JWKS bootstrap config for local stacks."""
+    active_signing_kid = os.environ.get(
+        "IDENTITY_ACTIVE_SIGNING_KID",
+        DEV_IDENTITY_ACTIVE_SIGNING_KID,
+    )
+    bootstrap_material_env_vars = (
+        "IDENTITY_SIGNING_PRIVATE_KEYRING_JSON",
+        "IDENTITY_SIGNING_PUBLIC_KEYRING_JSON",
+        "IDENTITY_JWKS_PUBLICATION_JSON",
+        "IDENTITY_VERIFIER_JWKS_JSON",
+        "SOORMA_AUTH_JWKS_JSON",
+        "SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON",
+    )
+    persisted_material = {
+        "identity_signing_private_keyring_json": "",
+        "identity_signing_public_keyring_json": "",
+        "identity_jwks_publication_json": "",
+    }
+    if any(not os.environ.get(env_var) for env_var in bootstrap_material_env_vars):
+        persisted_material = load_or_create_dev_identity_material(
+            soorma_dir or get_soorma_dir(),
+            active_signing_kid,
+        )
+    private_keyring_json = os.environ.get(
+        "IDENTITY_SIGNING_PRIVATE_KEYRING_JSON",
+        persisted_material["identity_signing_private_keyring_json"],
+    )
+    public_keyring_json = os.environ.get(
+        "IDENTITY_SIGNING_PUBLIC_KEYRING_JSON",
+        persisted_material["identity_signing_public_keyring_json"],
+    )
+    jwks_publication_json = os.environ.get(
+        "IDENTITY_JWKS_PUBLICATION_JSON",
+        persisted_material["identity_jwks_publication_json"],
+    )
+    verifier_jwks_json = os.environ.get(
+        "IDENTITY_VERIFIER_JWKS_JSON",
+        jwks_publication_json,
+    )
+    auth_jwks_json = os.environ.get(
+        "SOORMA_AUTH_JWKS_JSON",
+        jwks_publication_json,
+    )
+    auth_public_keys_json = os.environ.get(
+        "SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON",
+        public_keyring_json,
+    )
+    return {
+        "identity_signing_algorithm": os.environ.get("IDENTITY_SIGNING_ALGORITHM", "RS256"),
+        "identity_active_signing_kid": active_signing_kid,
+        "identity_signing_private_keyring_json": private_keyring_json,
+        "identity_signing_public_keyring_json": public_keyring_json,
+        "identity_jwks_publication_json": jwks_publication_json,
+        "identity_verifier_jwks_json": verifier_jwks_json,
+        "soorma_auth_jwks_json": auth_jwks_json,
+        "soorma_auth_jwt_public_keys_json": auth_public_keys_json,
+    }
 
 
 def determine_bootstrap_outcome(state_file: Path, fingerprint: str) -> str:
@@ -754,10 +909,9 @@ def dev_stack(
     # Defaults are intentionally deterministic for local-only stacks.
     openai_api_key = os.environ.get("OPENAI_API_KEY", "")
     identity_admin_api_key = os.environ.get("IDENTITY_ADMIN_API_KEY", "dev-identity-admin")
-    identity_signing_key = os.environ.get("IDENTITY_SIGNING_KEY", "dev-identity-signing-key")
-    soorma_auth_jwt_secret = os.environ.get("SOORMA_AUTH_JWT_SECRET", identity_signing_key)
     soorma_auth_jwt_issuer = os.environ.get("SOORMA_AUTH_JWT_ISSUER", "soorma-identity-service")
     soorma_auth_jwt_audience = os.environ.get("SOORMA_AUTH_JWT_AUDIENCE", "soorma-services")
+    identity_bootstrap_config = resolve_dev_identity_bootstrap_config()
     
     # Write .env file with custom ports and service images
     env_content = f"""# Soorma Local Development Environment
@@ -776,8 +930,14 @@ IDENTITY_SERVICE_IMAGE={identity_service_image or 'identity-service:latest'}
 POSTGRES_PORT={postgres_port}
 OPENAI_API_KEY={openai_api_key}
 IDENTITY_ADMIN_API_KEY={identity_admin_api_key}
-IDENTITY_SIGNING_KEY={identity_signing_key}
-SOORMA_AUTH_JWT_SECRET={soorma_auth_jwt_secret}
+IDENTITY_SIGNING_ALGORITHM={identity_bootstrap_config['identity_signing_algorithm']}
+IDENTITY_ACTIVE_SIGNING_KID={identity_bootstrap_config['identity_active_signing_kid']}
+IDENTITY_SIGNING_PRIVATE_KEYRING_JSON={json.dumps(identity_bootstrap_config['identity_signing_private_keyring_json'])}
+IDENTITY_SIGNING_PUBLIC_KEYRING_JSON={json.dumps(identity_bootstrap_config['identity_signing_public_keyring_json'])}
+IDENTITY_JWKS_PUBLICATION_JSON={json.dumps(identity_bootstrap_config['identity_jwks_publication_json'])}
+IDENTITY_VERIFIER_JWKS_JSON={json.dumps(identity_bootstrap_config['identity_verifier_jwks_json'])}
+SOORMA_AUTH_JWKS_JSON={json.dumps(identity_bootstrap_config['soorma_auth_jwks_json'])}
+SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON={json.dumps(identity_bootstrap_config['soorma_auth_jwt_public_keys_json'])}
 SOORMA_AUTH_JWT_ISSUER={soorma_auth_jwt_issuer}
 SOORMA_AUTH_JWT_AUDIENCE={soorma_auth_jwt_audience}
 """
@@ -828,8 +988,14 @@ SOORMA_AUTH_JWT_AUDIENCE={soorma_auth_jwt_audience}
         "tracker_service_image": tracker_service_image,
         "identity_service_image": identity_service_image,
         "identity_admin_api_key": identity_admin_api_key,
-        "identity_signing_key": identity_signing_key,
-        "soorma_auth_jwt_secret": soorma_auth_jwt_secret,
+        "identity_signing_algorithm": identity_bootstrap_config["identity_signing_algorithm"],
+        "identity_active_signing_kid": identity_bootstrap_config["identity_active_signing_kid"],
+        "identity_signing_private_keyring_json": identity_bootstrap_config["identity_signing_private_keyring_json"],
+        "identity_signing_public_keyring_json": identity_bootstrap_config["identity_signing_public_keyring_json"],
+        "identity_jwks_publication_json": identity_bootstrap_config["identity_jwks_publication_json"],
+        "identity_verifier_jwks_json": identity_bootstrap_config["identity_verifier_jwks_json"],
+        "soorma_auth_jwks_json": identity_bootstrap_config["soorma_auth_jwks_json"],
+        "soorma_auth_jwt_public_keys_json": identity_bootstrap_config["soorma_auth_jwt_public_keys_json"],
         "soorma_auth_jwt_issuer": soorma_auth_jwt_issuer,
         "soorma_auth_jwt_audience": soorma_auth_jwt_audience,
     }
@@ -941,9 +1107,10 @@ SOORMA_AUTH_JWT_AUDIENCE={soorma_auth_jwt_audience}
     typer.echo(f"  export SOORMA_NATS_URL=nats://localhost:{nats_port}")
     typer.echo("  # Optional local overrides for identity/JWT testing:")
     typer.echo("  export IDENTITY_ADMIN_API_KEY=dev-identity-admin")
-    typer.echo("  export IDENTITY_SIGNING_KEY=dev-identity-signing-key")
-    typer.echo("  export SOORMA_AUTH_JWT_SECRET=dev-identity-signing-key")
+    typer.echo("  export IDENTITY_SIGNING_ALGORITHM=RS256")
+    typer.echo(f"  export IDENTITY_ACTIVE_SIGNING_KID={identity_bootstrap_config['identity_active_signing_kid']}")
     typer.echo("  export SOORMA_AUTH_JWT_ISSUER=soorma-identity-service")
     typer.echo("  export SOORMA_AUTH_JWT_AUDIENCE=soorma-services")
+    typer.echo("  # If host-side code verifies JWTs, source SOORMA_AUTH_JWKS_JSON from .soorma/.env")
     typer.echo("  python agent.py")
     raise typer.Exit(0)

--- a/sdk/python/soorma/context.py
+++ b/sdk/python/soorma/context.py
@@ -43,7 +43,7 @@ from soorma_common.tracker import (
     PlanProgress,
     TaskExecution,
 )
-from .auth import AuthTokenProvider
+from .auth import AuthTokenProvider, build_optional_auth_kwargs
 from .events import EventClient
 from .memory import MemoryServiceClient
 from .registry.client import RegistryClient
@@ -123,8 +123,7 @@ class MemoryClient:
         if self._client is None:
             self._client = MemoryServiceClient(
                 base_url=self.base_url,
-                auth_token=self.auth_token,
-                auth_token_provider=self.auth_token_provider,
+                **build_optional_auth_kwargs(self.auth_token, self.auth_token_provider),
             )
             # Test connection
             try:
@@ -1791,14 +1790,13 @@ class PlatformContext:
         """
         self.registry = registry or RegistryClient(
             base_url=os.getenv("SOORMA_REGISTRY_URL", "http://localhost:8081"),
-            auth_token=auth_token,
-            auth_token_provider=auth_token_provider,
+            **build_optional_auth_kwargs(auth_token, auth_token_provider),
         )
-        self.memory = memory or MemoryClient(auth_token=auth_token, auth_token_provider=auth_token_provider)
+        self.memory = memory or MemoryClient(**build_optional_auth_kwargs(auth_token, auth_token_provider))
         self.bus = bus or BusClient(
-            event_client=EventClient(auth_token=auth_token, auth_token_provider=auth_token_provider)
+            event_client=EventClient(**build_optional_auth_kwargs(auth_token, auth_token_provider))
         )
-        self.tracker = tracker or TrackerClient(auth_token=auth_token, auth_token_provider=auth_token_provider)
+        self.tracker = tracker or TrackerClient(**build_optional_auth_kwargs(auth_token, auth_token_provider))
         self.identity = identity or IdentityClient()
         # Toolkit reuses registry client - no async with needed when using context.toolkit!
         self.toolkit = toolkit or EventToolkit(registry_url=self.registry.base_url, registry_client=self.registry)

--- a/sdk/python/soorma/context.py
+++ b/sdk/python/soorma/context.py
@@ -1807,7 +1807,11 @@ class PlatformContext:
             self.set_auth_token_provider(auth_token_provider)
     
     @classmethod
-    def from_env(cls) -> "PlatformContext":
+    def from_env(
+        cls,
+        auth_token: Optional[str] = None,
+        auth_token_provider: Optional[AuthTokenProvider] = None,
+    ) -> "PlatformContext":
         """
         Create a PlatformContext from environment variables (convenience method).
         
@@ -1817,7 +1821,6 @@ class PlatformContext:
             SOORMA_MEMORY_URL: Memory service URL (default: http://localhost:8083)
             SOORMA_TRACKER_URL: Tracker service URL (default: http://localhost:8084)
             SOORMA_IDENTITY_URL: Identity service URL (default: http://localhost:8085)
-            SOORMA_AUTH_TOKEN: Optional injected bearer token for bearer-auth service calls
             
         Returns:
             PlatformContext with clients configured from environment
@@ -1828,13 +1831,13 @@ class PlatformContext:
         """
         event_client = EventClient(
             event_service_url=os.getenv("SOORMA_EVENT_SERVICE_URL", "http://localhost:8082"),
-            auth_token=os.getenv("SOORMA_AUTH_TOKEN"),
+            **build_optional_auth_kwargs(auth_token, auth_token_provider),
         )
         
         registry_url = os.getenv("SOORMA_REGISTRY_URL", "http://localhost:8081")
         registry_client = RegistryClient(
             base_url=registry_url,
-            auth_token=os.getenv("SOORMA_AUTH_TOKEN"),
+            **build_optional_auth_kwargs(auth_token, auth_token_provider),
         )
         
         return cls(
@@ -1845,13 +1848,14 @@ class PlatformContext:
             bus=BusClient(event_client=event_client),
             tracker=TrackerClient(
                 base_url=os.getenv("SOORMA_TRACKER_URL", "http://localhost:8084"),
-                auth_token=os.getenv("SOORMA_AUTH_TOKEN"),
+                **build_optional_auth_kwargs(auth_token, auth_token_provider),
             ),
             identity=IdentityClient(
                 base_url=os.getenv("SOORMA_IDENTITY_URL", "http://localhost:8085"),
             ),
             toolkit=EventToolkit(registry_url=registry_url, registry_client=registry_client),
-            auth_token=os.getenv("SOORMA_AUTH_TOKEN"),
+            auth_token=auth_token,
+            auth_token_provider=auth_token_provider,
         )
 
     def set_auth_token(self, auth_token: Optional[str]) -> None:

--- a/sdk/python/soorma/context.py
+++ b/sdk/python/soorma/context.py
@@ -43,6 +43,7 @@ from soorma_common.tracker import (
     PlanProgress,
     TaskExecution,
 )
+from .auth import AuthTokenProvider
 from .events import EventClient
 from .memory import MemoryServiceClient
 from .registry.client import RegistryClient
@@ -106,6 +107,7 @@ class MemoryClient:
     """
     base_url: str = field(default_factory=lambda: os.getenv("SOORMA_MEMORY_SERVICE_URL", "http://localhost:8083"))
     auth_token: Optional[str] = None
+    auth_token_provider: Optional[AuthTokenProvider] = None
     # Note: Local fallback removed - Memory Service required for multi-agent workflows
     _client: Optional[MemoryServiceClient] = field(default=None, repr=False, init=False)
     _bound_event_identity: contextvars.ContextVar[Optional[Dict[str, Any]]] = field(
@@ -119,7 +121,11 @@ class MemoryClient:
     
     async def _ensure_client(self) -> MemoryServiceClient:
         if self._client is None:
-            self._client = MemoryServiceClient(base_url=self.base_url, auth_token=self.auth_token)
+            self._client = MemoryServiceClient(
+                base_url=self.base_url,
+                auth_token=self.auth_token,
+                auth_token_provider=self.auth_token_provider,
+            )
             # Test connection
             try:
                 await self._client.health()
@@ -140,6 +146,12 @@ class MemoryClient:
         self.auth_token = auth_token
         if self._client is not None:
             self._client.auth_token = auth_token
+
+    def set_auth_token_provider(self, auth_token_provider: Optional[AuthTokenProvider]) -> None:
+        """Set optional bearer token provider used for downstream service calls."""
+        self.auth_token_provider = auth_token_provider
+        if self._client is not None:
+            self._client.auth_token_provider = auth_token_provider
 
     def bind_event_metadata(self, event: "EventEnvelope") -> contextvars.Token:
         """Bind current event identity for implicit wrapper defaults."""
@@ -1088,6 +1100,14 @@ class BusClient:
             user_id if user_id is not None else metadata.get("user_id"),
             session_id if session_id is not None else metadata.get("session_id"),
         )
+
+    def set_auth_token(self, auth_token: Optional[str]) -> None:
+        """Inject or replace bearer token for event-bus requests."""
+        self.event_client.set_auth_token(auth_token)
+
+    def set_auth_token_provider(self, auth_token_provider: Optional[AuthTokenProvider]) -> None:
+        """Inject or replace bearer token provider for event-bus requests."""
+        self.event_client.set_auth_token_provider(auth_token_provider)
     
     async def publish(
         self,
@@ -1451,6 +1471,7 @@ class TrackerClient:
     """
     base_url: str = field(default_factory=lambda: os.getenv("SOORMA_TRACKER_URL", "http://localhost:8084"))
     auth_token: Optional[str] = None
+    auth_token_provider: Optional[AuthTokenProvider] = None
     _client: Optional["TrackerServiceClient"] = field(default=None, repr=False, init=False)
     _bound_event_identity: contextvars.ContextVar[Optional[Dict[str, Any]]] = field(
         default_factory=lambda: contextvars.ContextVar(
@@ -1465,7 +1486,11 @@ class TrackerClient:
         """Lazy initialization of TrackerServiceClient."""
         if self._client is None:
             from .tracker.client import TrackerServiceClient
-            self._client = TrackerServiceClient(base_url=self.base_url, auth_token=self.auth_token)
+            self._client = TrackerServiceClient(
+                base_url=self.base_url,
+                auth_token=self.auth_token,
+                auth_token_provider=self.auth_token_provider,
+            )
         return self._client
 
     def set_auth_token(self, auth_token: Optional[str]) -> None:
@@ -1473,6 +1498,12 @@ class TrackerClient:
         self.auth_token = auth_token
         if self._client is not None:
             self._client.auth_token = auth_token
+
+    def set_auth_token_provider(self, auth_token_provider: Optional[AuthTokenProvider]) -> None:
+        """Set optional bearer token provider used for downstream tracker calls."""
+        self.auth_token_provider = auth_token_provider
+        if self._client is not None:
+            self._client.auth_token_provider = auth_token_provider
 
     def bind_event_metadata(self, event: "EventEnvelope") -> contextvars.Token:
         """Bind current event identity for implicit tracker defaults."""
@@ -1745,6 +1776,7 @@ class PlatformContext:
         identity: IdentityClient = None,
         toolkit: EventToolkit = None,
         auth_token: Optional[str] = None,
+        auth_token_provider: Optional[AuthTokenProvider] = None,
     ):
         """
         Create a PlatformContext with configured clients.
@@ -1757,16 +1789,24 @@ class PlatformContext:
             identity: Identity wrapper client (optional)
             toolkit: EventToolkit for AI-friendly event utilities (optional)
         """
-        self.registry = registry or RegistryClient(base_url=os.getenv("SOORMA_REGISTRY_URL", "http://localhost:8081"))
-        self.memory = memory or MemoryClient(auth_token=auth_token)
-        self.bus = bus or BusClient()
-        self.tracker = tracker or TrackerClient(auth_token=auth_token)
+        self.registry = registry or RegistryClient(
+            base_url=os.getenv("SOORMA_REGISTRY_URL", "http://localhost:8081"),
+            auth_token=auth_token,
+            auth_token_provider=auth_token_provider,
+        )
+        self.memory = memory or MemoryClient(auth_token=auth_token, auth_token_provider=auth_token_provider)
+        self.bus = bus or BusClient(
+            event_client=EventClient(auth_token=auth_token, auth_token_provider=auth_token_provider)
+        )
+        self.tracker = tracker or TrackerClient(auth_token=auth_token, auth_token_provider=auth_token_provider)
         self.identity = identity or IdentityClient()
         # Toolkit reuses registry client - no async with needed when using context.toolkit!
         self.toolkit = toolkit or EventToolkit(registry_url=self.registry.base_url, registry_client=self.registry)
 
         if auth_token is not None:
             self.set_auth_token(auth_token)
+        if auth_token_provider is not None:
+            self.set_auth_token_provider(auth_token_provider)
     
     @classmethod
     def from_env(cls) -> "PlatformContext":
@@ -1779,7 +1819,7 @@ class PlatformContext:
             SOORMA_MEMORY_URL: Memory service URL (default: http://localhost:8083)
             SOORMA_TRACKER_URL: Tracker service URL (default: http://localhost:8084)
             SOORMA_IDENTITY_URL: Identity service URL (default: http://localhost:8085)
-            SOORMA_AUTH_TOKEN: Optional injected bearer token for memory/tracker calls
+            SOORMA_AUTH_TOKEN: Optional injected bearer token for bearer-auth service calls
             
         Returns:
             PlatformContext with clients configured from environment
@@ -1790,10 +1830,14 @@ class PlatformContext:
         """
         event_client = EventClient(
             event_service_url=os.getenv("SOORMA_EVENT_SERVICE_URL", "http://localhost:8082"),
+            auth_token=os.getenv("SOORMA_AUTH_TOKEN"),
         )
         
         registry_url = os.getenv("SOORMA_REGISTRY_URL", "http://localhost:8081")
-        registry_client = RegistryClient(base_url=registry_url)
+        registry_client = RegistryClient(
+            base_url=registry_url,
+            auth_token=os.getenv("SOORMA_AUTH_TOKEN"),
+        )
         
         return cls(
             registry=registry_client,
@@ -1814,8 +1858,17 @@ class PlatformContext:
 
     def set_auth_token(self, auth_token: Optional[str]) -> None:
         """Inject or replace bearer token for downstream service wrappers."""
+        self.registry.set_auth_token(auth_token)
+        self.bus.set_auth_token(auth_token)
         self.memory.set_auth_token(auth_token)
         self.tracker.set_auth_token(auth_token)
+
+    def set_auth_token_provider(self, auth_token_provider: Optional[AuthTokenProvider]) -> None:
+        """Inject or replace bearer token provider for downstream service wrappers."""
+        self.registry.set_auth_token_provider(auth_token_provider)
+        self.bus.set_auth_token_provider(auth_token_provider)
+        self.memory.set_auth_token_provider(auth_token_provider)
+        self.tracker.set_auth_token_provider(auth_token_provider)
     
     async def close(self) -> None:
         """Close all clients."""

--- a/sdk/python/soorma/events.py
+++ b/sdk/python/soorma/events.py
@@ -41,7 +41,6 @@ from uuid import uuid4
 
 from .auth import AuthTokenProvider, resolve_auth_token
 from soorma_common.events import EventEnvelope, EventTopic
-from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 
 logger = logging.getLogger(__name__)
 
@@ -101,10 +100,7 @@ class EventClient:
         self.source = source or self.agent_id
         self.auth_token = auth_token or os.getenv("SOORMA_AUTH_TOKEN")
         self.auth_token_provider = auth_token_provider
-        self.platform_tenant_id = platform_tenant_id or os.getenv(
-            "SOORMA_PLATFORM_TENANT_ID",
-            DEFAULT_PLATFORM_TENANT_ID,
-        )
+        self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
         self.tenant_id = tenant_id
         self.session_id = session_id
         

--- a/sdk/python/soorma/events.py
+++ b/sdk/python/soorma/events.py
@@ -86,7 +86,8 @@ class EventClient:
             event_service_url: Base URL of the Event Service (e.g., "http://localhost:8082")
             agent_id: Unique identifier for this agent (auto-generated if not provided)
             source: Source identifier for events (defaults to agent_id)
-            platform_tenant_id: Platform tenant ID for X-Tenant-ID header
+            platform_tenant_id: Legacy platform tenant default retained only for
+                envelope metadata compatibility
             tenant_id: Default tenant ID for multi-tenancy
             session_id: Default session ID for correlation
             events_consumed: Optional list of EventDefinition objects to auto-register
@@ -98,7 +99,7 @@ class EventClient:
         self.event_service_url = event_service_url.rstrip("/")
         self.agent_id = agent_id or f"agent-{str(uuid4())[:8]}"
         self.source = source or self.agent_id
-        self.auth_token = auth_token or os.getenv("SOORMA_AUTH_TOKEN")
+        self.auth_token = auth_token
         self.auth_token_provider = auth_token_provider
         self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
         self.tenant_id = tenant_id

--- a/sdk/python/soorma/events.py
+++ b/sdk/python/soorma/events.py
@@ -34,7 +34,6 @@ Usage:
 import asyncio
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 from uuid import uuid4
@@ -86,8 +85,8 @@ class EventClient:
             event_service_url: Base URL of the Event Service (e.g., "http://localhost:8082")
             agent_id: Unique identifier for this agent (auto-generated if not provided)
             source: Source identifier for events (defaults to agent_id)
-            platform_tenant_id: Legacy platform tenant default retained only for
-                envelope metadata compatibility
+            platform_tenant_id: Optional explicit platform tenant value retained
+                only for envelope metadata compatibility.
             tenant_id: Default tenant ID for multi-tenancy
             session_id: Default session ID for correlation
             events_consumed: Optional list of EventDefinition objects to auto-register
@@ -101,7 +100,7 @@ class EventClient:
         self.source = source or self.agent_id
         self.auth_token = auth_token
         self.auth_token_provider = auth_token_provider
-        self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
+        self.platform_tenant_id = platform_tenant_id
         self.tenant_id = tenant_id
         self.session_id = session_id
         

--- a/sdk/python/soorma/events.py
+++ b/sdk/python/soorma/events.py
@@ -34,10 +34,12 @@ Usage:
 import asyncio
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 from uuid import uuid4
 
+from .auth import AuthTokenProvider, resolve_auth_token
 from soorma_common.events import EventEnvelope, EventTopic
 from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 
@@ -68,6 +70,8 @@ class EventClient:
         event_service_url: str = "http://localhost:8082",
         agent_id: Optional[str] = None,
         source: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        auth_token_provider: Optional[AuthTokenProvider] = None,
         platform_tenant_id: Optional[str] = None,
         tenant_id: Optional[str] = None,
         session_id: Optional[str] = None,
@@ -95,7 +99,12 @@ class EventClient:
         self.event_service_url = event_service_url.rstrip("/")
         self.agent_id = agent_id or f"agent-{str(uuid4())[:8]}"
         self.source = source or self.agent_id
-        self.platform_tenant_id = platform_tenant_id or DEFAULT_PLATFORM_TENANT_ID
+        self.auth_token = auth_token or os.getenv("SOORMA_AUTH_TOKEN")
+        self.auth_token_provider = auth_token_provider
+        self.platform_tenant_id = platform_tenant_id or os.getenv(
+            "SOORMA_PLATFORM_TENANT_ID",
+            DEFAULT_PLATFORM_TENANT_ID,
+        )
         self.tenant_id = tenant_id
         self.session_id = session_id
         
@@ -125,6 +134,21 @@ class EventClient:
             for e in events_consumed:
                 if hasattr(e, "event_name"):
                     self._pending_event_definitions.append(e)
+
+    def set_auth_token(self, auth_token: Optional[str]) -> None:
+        """Inject or replace bearer token for event-service requests."""
+        self.auth_token = auth_token
+
+    def set_auth_token_provider(self, auth_token_provider: Optional[AuthTokenProvider]) -> None:
+        """Inject or replace bearer token provider for event-service requests."""
+        self.auth_token_provider = auth_token_provider
+
+    async def _build_auth_headers(self) -> dict[str, str]:
+        """Build outbound auth headers for event-service calls."""
+        token = await resolve_auth_token(self.auth_token, self.auth_token_provider)
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}"}
     
     # =========================================================================
     # Decorator for registering handlers
@@ -240,7 +264,11 @@ class EventClient:
         from soorma_common import PayloadSchema
 
         registry_url = _os.getenv("SOORMA_REGISTRY_URL", "http://localhost:8081")
-        registry_client = RegistryClient(base_url=registry_url)
+        registry_client = RegistryClient(
+            base_url=registry_url,
+            auth_token=self.auth_token,
+            auth_token_provider=self.auth_token_provider,
+        )
 
         for event_def in self._pending_event_definitions:
             # Register event definition
@@ -407,7 +435,7 @@ class EventClient:
             response = await self._http_client.post(
                 url,
                 json={"event": event},
-                headers={"X-Tenant-ID": self.platform_tenant_id},
+                headers=await self._build_auth_headers(),
                 timeout=30.0,
             )
             
@@ -494,7 +522,7 @@ class EventClient:
         
         logger.info(f"Connecting to SSE stream: {url}")
         
-        async with self._http_client.stream("GET", url) as response:
+        async with self._http_client.stream("GET", url, headers=await self._build_auth_headers()) as response:
             if response.status_code != 200:
                 raise ConnectionError(f"SSE connection failed: {response.status_code}")
             

--- a/sdk/python/soorma/identity/client.py
+++ b/sdk/python/soorma/identity/client.py
@@ -1,11 +1,9 @@
 """Identity Service client (Layer 1)."""
 
-from datetime import datetime, timedelta, timezone
 import os
 from typing import Optional, TypeVar
 
 import httpx
-import jwt
 
 from soorma_common.models import (
     BaseDTO,
@@ -20,21 +18,9 @@ from soorma_common.models import (
     TokenIssueRequest,
     TokenIssueResponse,
 )
-from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 
 
 ResponseT = TypeVar("ResponseT", bound=BaseDTO)
-
-_CALLER_JWT_ENV = "SOORMA_IDENTITY_CALLER_JWT"
-_JWT_SECRET_ENV = "SOORMA_AUTH_JWT_SECRET"
-_JWT_ISSUER_ENV = "SOORMA_AUTH_JWT_ISSUER"
-_JWT_AUDIENCE_ENV = "SOORMA_AUTH_JWT_AUDIENCE"
-_INCLUDE_LEGACY_ALIAS_ENV = "SOORMA_IDENTITY_INCLUDE_LEGACY_ALIAS"
-
-
-def _is_truthy(value: Optional[str]) -> bool:
-    """Return True when env-style flag values are enabled."""
-    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 class IdentityServiceClient:
@@ -44,16 +30,18 @@ class IdentityServiceClient:
         self,
         base_url: str = "http://localhost:8085",
         timeout: float = 30.0,
-        platform_tenant_id: Optional[str] = None,
         admin_api_key: Optional[str] = None,
-        caller_jwt: Optional[str] = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self.platform_tenant_id = platform_tenant_id or DEFAULT_PLATFORM_TENANT_ID
+        self.platform_tenant_id: Optional[str] = None
         self.admin_api_key = admin_api_key or os.getenv("IDENTITY_ADMIN_API_KEY", "dev-identity-admin")
-        self.caller_jwt = caller_jwt or os.getenv(_CALLER_JWT_ENV)
         self._client = httpx.AsyncClient(timeout=timeout)
+
+    def set_platform_tenant_id(self, platform_tenant_id: Optional[str]) -> None:
+        """Bind the platform tenant ID once onboarding or discovery has provided it."""
+        value = str(platform_tenant_id or "").strip()
+        self.platform_tenant_id = value or None
 
     async def close(self) -> None:
         """Close underlying HTTP client."""
@@ -69,58 +57,16 @@ class IdentityServiceClient:
         self,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> dict[str, str]:
         """Build required identity headers for identity-service calls."""
-        if not service_tenant_id or not service_user_id:
-            raise ValueError("service_tenant_id and service_user_id are required")
-
-        headers = {
-            "X-Tenant-ID": self.platform_tenant_id,
-            "X-Identity-Admin-Key": self.admin_api_key,
-        }
-
-        caller_jwt = self._resolve_caller_jwt(service_tenant_id, service_user_id)
-        if caller_jwt:
-            headers["Authorization"] = f"Bearer {caller_jwt}"
-            if _is_truthy(os.getenv(_INCLUDE_LEGACY_ALIAS_ENV)):
-                headers["X-Service-Tenant-ID"] = service_tenant_id
-                headers["X-User-ID"] = service_user_id
-            return headers
-
-        headers["X-Service-Tenant-ID"] = service_tenant_id
-        headers["X-User-ID"] = service_user_id
+        resolved_platform_tenant_id = str(
+            platform_tenant_id or self.platform_tenant_id or ""
+        ).strip() or None
+        headers = {"X-Identity-Admin-Key": self.admin_api_key}
+        if resolved_platform_tenant_id is not None:
+            headers["X-Tenant-ID"] = resolved_platform_tenant_id
         return headers
-
-    def _resolve_caller_jwt(self, service_tenant_id: str, service_user_id: str) -> Optional[str]:
-        """Resolve outbound caller JWT from explicit token or local signing config."""
-        explicit_token = str(self.caller_jwt or "").strip()
-        if explicit_token:
-            return explicit_token
-
-        jwt_secret = os.getenv(_JWT_SECRET_ENV)
-        if not jwt_secret:
-            return None
-
-        issued_at = datetime.now(timezone.utc)
-        claims: dict[str, object] = {
-            "platform_tenant_id": self.platform_tenant_id,
-            "service_tenant_id": service_tenant_id,
-            "service_user_id": service_user_id,
-            "principal_id": service_user_id,
-            "principal_type": "service",
-            "roles": ["service"],
-            "iat": int(issued_at.timestamp()),
-            "exp": int((issued_at + timedelta(minutes=5)).timestamp()),
-        }
-
-        jwt_issuer = str(os.getenv(_JWT_ISSUER_ENV) or "").strip()
-        jwt_audience = str(os.getenv(_JWT_AUDIENCE_ENV) or "").strip()
-        if jwt_issuer:
-            claims["iss"] = jwt_issuer
-        if jwt_audience:
-            claims["aud"] = jwt_audience
-
-        return str(jwt.encode(claims, jwt_secret, algorithm="HS256"))
 
     async def _post(
         self,
@@ -129,11 +75,16 @@ class IdentityServiceClient:
         response_model: type[ResponseT],
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> ResponseT:
         """Execute POST request against identity-service endpoint."""
         response = await self._client.post(
             f"{self.base_url}{path}",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=self._build_identity_headers(
+                service_tenant_id,
+                service_user_id,
+                platform_tenant_id=platform_tenant_id,
+            ),
             json=payload.model_dump(by_alias=True),
         )
         response.raise_for_status()
@@ -146,11 +97,16 @@ class IdentityServiceClient:
         response_model: type[ResponseT],
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> ResponseT:
         """Execute PUT request against identity-service endpoint."""
         response = await self._client.put(
             f"{self.base_url}{path}",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=self._build_identity_headers(
+                service_tenant_id,
+                service_user_id,
+                platform_tenant_id=platform_tenant_id,
+            ),
             json=payload.model_dump(by_alias=True),
         )
         response.raise_for_status()
@@ -161,6 +117,7 @@ class IdentityServiceClient:
         payload: OnboardingRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> OnboardingResponse:
         """Create tenant identity domain and bootstrap admin principal."""
         return await self._post(
@@ -169,6 +126,7 @@ class IdentityServiceClient:
             OnboardingResponse,
             service_tenant_id,
             service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )
 
     async def create_principal(
@@ -176,6 +134,7 @@ class IdentityServiceClient:
         payload: PrincipalRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> PrincipalResponse:
         """Create principal."""
         return await self._post(
@@ -184,6 +143,7 @@ class IdentityServiceClient:
             PrincipalResponse,
             service_tenant_id,
             service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )
 
     async def update_principal(
@@ -192,6 +152,7 @@ class IdentityServiceClient:
         payload: PrincipalRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> PrincipalResponse:
         """Update principal."""
         return await self._put(
@@ -200,6 +161,7 @@ class IdentityServiceClient:
             PrincipalResponse,
             service_tenant_id,
             service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )
 
     async def revoke_principal(
@@ -207,11 +169,16 @@ class IdentityServiceClient:
         principal_id: str,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> PrincipalResponse:
         """Revoke principal."""
         response = await self._client.post(
             f"{self.base_url}/v1/identity/principals/{principal_id}/revoke",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=self._build_identity_headers(
+                service_tenant_id,
+                service_user_id,
+                platform_tenant_id=platform_tenant_id,
+            ),
             json={},
         )
         response.raise_for_status()
@@ -222,6 +189,7 @@ class IdentityServiceClient:
         payload: TokenIssueRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> TokenIssueResponse:
         """Issue platform/delegated token based on issuance policy."""
         return await self._post(
@@ -230,6 +198,7 @@ class IdentityServiceClient:
             TokenIssueResponse,
             service_tenant_id=service_tenant_id,
             service_user_id=service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )
 
     async def register_delegated_issuer(
@@ -237,6 +206,7 @@ class IdentityServiceClient:
         payload: DelegatedIssuerRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> DelegatedIssuerResponse:
         """Register delegated issuer trust metadata."""
         return await self._post(
@@ -245,6 +215,7 @@ class IdentityServiceClient:
             DelegatedIssuerResponse,
             service_tenant_id,
             service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )
 
     async def update_delegated_issuer(
@@ -253,6 +224,7 @@ class IdentityServiceClient:
         payload: DelegatedIssuerRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> DelegatedIssuerResponse:
         """Update delegated issuer trust metadata."""
         return await self._put(
@@ -261,6 +233,7 @@ class IdentityServiceClient:
             DelegatedIssuerResponse,
             service_tenant_id,
             service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )
 
     async def evaluate_mapping(
@@ -268,6 +241,7 @@ class IdentityServiceClient:
         payload: MappingEvaluationRequest,
         service_tenant_id: str,
         service_user_id: str,
+        platform_tenant_id: Optional[str] = None,
     ) -> MappingEvaluationResponse:
         """Evaluate identity mapping collision policy."""
         return await self._post(
@@ -276,4 +250,5 @@ class IdentityServiceClient:
             MappingEvaluationResponse,
             service_tenant_id,
             service_user_id,
+            platform_tenant_id=platform_tenant_id,
         )

--- a/sdk/python/soorma/memory/client.py
+++ b/sdk/python/soorma/memory/client.py
@@ -8,9 +8,6 @@ framework with four types of memory:
 - Procedural Memory: Dynamic prompts, rules, and skills
 - Working Memory: Plan-scoped shared state for multi-agent collaboration
 """
-
-import os
-
 from typing import Any, Dict, List, Optional
 import httpx
 
@@ -67,15 +64,16 @@ class MemoryServiceClient:
         Args:
             base_url: Base URL of the memory service (e.g., "http://localhost:8083")
             timeout: HTTP request timeout in seconds
-            platform_tenant_id: Platform tenant identifier for X-Tenant-ID header
+            platform_tenant_id: Optional explicit platform tenant value retained
+                for compatibility only. It is not projected on the active bearer-auth path.
             
         Note:
             service_tenant_id and service_user_id are passed per-request in method
-            calls. platform_tenant_id is fixed for the client lifetime.
+            calls. platform_tenant_id is compatibility-only state.
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
+        self.platform_tenant_id = platform_tenant_id
         self.auth_token = auth_token
         self.auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)

--- a/sdk/python/soorma/memory/client.py
+++ b/sdk/python/soorma/memory/client.py
@@ -12,6 +12,7 @@ framework with four types of memory:
 from typing import Any, Dict, List, Optional
 import httpx
 
+from soorma.auth import AuthTokenProvider, resolve_auth_token
 from soorma_common.models import (
     SemanticMemoryCreate,
     SemanticMemoryResponse,
@@ -57,6 +58,7 @@ class MemoryServiceClient:
         timeout: float = 30.0,
         platform_tenant_id: Optional[str] = None,
         auth_token: Optional[str] = None,
+        auth_token_provider: Optional[AuthTokenProvider] = None,
     ):
         """
         Initialize the memory client.
@@ -74,6 +76,7 @@ class MemoryServiceClient:
         self.timeout = timeout
         self.platform_tenant_id = platform_tenant_id or DEFAULT_PLATFORM_TENANT_ID
         self.auth_token = auth_token
+        self.auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)
     
     async def close(self):
@@ -88,25 +91,16 @@ class MemoryServiceClient:
         """Async context manager exit."""
         await self.close()
 
-    def _build_identity_headers(
+    async def _build_identity_headers(
         self,
         service_tenant_id: str,
         service_user_id: str,
     ) -> Dict[str, str]:
         """Build required identity headers for Memory Service requests."""
-        if self.auth_token:
-            return {"Authorization": f"Bearer {self.auth_token}"}
-
-        if not service_tenant_id or not service_user_id:
-            raise ValueError(
-                "service_tenant_id and service_user_id are required"
-            )
-
-        return {
-            "X-Tenant-ID": self.platform_tenant_id,
-            "X-Service-Tenant-ID": service_tenant_id,
-            "X-User-ID": service_user_id,
-        }
+        token = await resolve_auth_token(self.auth_token, self.auth_token_provider)
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}"}
     
     # Semantic Memory Methods
     
@@ -181,7 +175,7 @@ class MemoryServiceClient:
         
         response = await self._client.post(
             f"{self.base_url}/v1/memory/semantic",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             json=data.model_dump(by_alias=True),
         )
         response.raise_for_status()
@@ -212,7 +206,7 @@ class MemoryServiceClient:
         """
         response = await self._client.post(
             f"{self.base_url}/v1/memory/semantic/query",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             params={
                 "query": query,
                 "limit": limit,
@@ -287,7 +281,7 @@ class MemoryServiceClient:
         response = await self._client.post(
             f"{self.base_url}/v1/memory/episodic",
             json=data.model_dump(by_alias=True),
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return EpisodicMemoryResponse.model_validate(response.json())
@@ -312,7 +306,7 @@ class MemoryServiceClient:
         """
         response = await self._client.get(
             f"{self.base_url}/v1/memory/episodic/recent",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             params={"agent_id": agent_id, "limit": limit},
         )
         response.raise_for_status()
@@ -340,7 +334,7 @@ class MemoryServiceClient:
         """
         response = await self._client.get(
             f"{self.base_url}/v1/memory/episodic/search",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             params={"agent_id": agent_id, "q": query, "limit": limit},
         )
         response.raise_for_status()
@@ -372,7 +366,7 @@ class MemoryServiceClient:
         """
         response = await self._client.get(
             f"{self.base_url}/v1/memory/procedural/context",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             params={"agent_id": agent_id, "q": context, "limit": limit},
         )
         response.raise_for_status()
@@ -406,7 +400,7 @@ class MemoryServiceClient:
         response = await self._client.put(
             f"{self.base_url}/v1/memory/working/{plan_id}/{key}",
             json=data.model_dump(by_alias=True),
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return WorkingMemoryResponse.model_validate(response.json())
@@ -435,7 +429,7 @@ class MemoryServiceClient:
         """
         response = await self._client.get(
             f"{self.base_url}/v1/memory/working/{plan_id}/{key}",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return WorkingMemoryResponse.model_validate(response.json())
@@ -491,7 +485,7 @@ class MemoryServiceClient:
             # Delete single key
             response = await self._client.delete(
                 f"{self.base_url}/v1/memory/working/{plan_id}/{key}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return WorkingMemoryDeleteKeyResponse.model_validate(response.json())
@@ -499,7 +493,7 @@ class MemoryServiceClient:
             # Delete all keys for plan
             response = await self._client.delete(
                 f"{self.base_url}/v1/memory/working/{plan_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return WorkingMemoryDeletePlanResponse.model_validate(response.json())
@@ -572,7 +566,7 @@ class MemoryServiceClient:
         response = await self._client.post(
             f"{self.base_url}/v1/memory/task-context",
             json=request_data.model_dump(by_alias=True),
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return TaskContextResponse.model_validate(response.json())
@@ -602,7 +596,7 @@ class MemoryServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/memory/task-context/{task_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return TaskContextResponse.model_validate(response.json())
@@ -643,7 +637,7 @@ class MemoryServiceClient:
         response = await self._client.put(
             f"{self.base_url}/v1/memory/task-context/{task_id}",
             json=request_data.model_dump(by_alias=True, exclude_none=True),
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return TaskContextResponse.model_validate(response.json())
@@ -673,7 +667,7 @@ class MemoryServiceClient:
         try:
             response = await self._client.delete(
                 f"{self.base_url}/v1/memory/task-context/{task_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return True
@@ -707,7 +701,7 @@ class MemoryServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/memory/task-context/by-subtask/{sub_task_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return TaskContextResponse.model_validate(response.json())
@@ -765,7 +759,7 @@ class MemoryServiceClient:
         try:
             response = await self._client.post(
                 f"{self.base_url}/v1/memory/plan-context",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
                 json=request_data.model_dump(by_alias=True),
             )
             response.raise_for_status()
@@ -806,7 +800,7 @@ class MemoryServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/memory/plan-context/{plan_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return PlanContextResponse.model_validate(response.json())
@@ -846,7 +840,7 @@ class MemoryServiceClient:
         
         response = await self._client.put(
             f"{self.base_url}/v1/memory/plan-context/{plan_id}",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             json=request_data.model_dump(by_alias=True, exclude_none=True),
         )
         response.raise_for_status()
@@ -874,7 +868,7 @@ class MemoryServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/memory/plan-context/by-correlation/{correlation_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return PlanContextResponse.model_validate(response.json())
@@ -923,7 +917,7 @@ class MemoryServiceClient:
         response = await self._client.post(
             f"{self.base_url}/v1/memory/plans",
             json=request_data.model_dump(by_alias=True),
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return PlanSummary.model_validate(response.json())
@@ -967,7 +961,7 @@ class MemoryServiceClient:
             # Then delete the Plan record itself
             response = await self._client.delete(
                 f"{self.base_url}/v1/memory/plans/{plan_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return True
@@ -1005,7 +999,7 @@ class MemoryServiceClient:
         
         response = await self._client.post(
             f"{self.base_url}/v1/memory/sessions",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             json=request_data.model_dump(by_alias=True),
         )
         response.raise_for_status()
@@ -1041,7 +1035,7 @@ class MemoryServiceClient:
         response = await self._client.get(
             f"{self.base_url}/v1/memory/plans",
             params=params,
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return [PlanSummary.model_validate(item) for item in response.json()]
@@ -1063,7 +1057,7 @@ class MemoryServiceClient:
         """
         response = await self._client.get(
             f"{self.base_url}/v1/memory/sessions",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             params={"limit": limit},
         )
         response.raise_for_status()

--- a/sdk/python/soorma/memory/client.py
+++ b/sdk/python/soorma/memory/client.py
@@ -94,19 +94,19 @@ class MemoryServiceClient:
         service_user_id: str,
     ) -> Dict[str, str]:
         """Build required identity headers for Memory Service requests."""
+        if self.auth_token:
+            return {"Authorization": f"Bearer {self.auth_token}"}
+
         if not service_tenant_id or not service_user_id:
             raise ValueError(
                 "service_tenant_id and service_user_id are required"
             )
 
-        headers = {
+        return {
             "X-Tenant-ID": self.platform_tenant_id,
             "X-Service-Tenant-ID": service_tenant_id,
             "X-User-ID": service_user_id,
         }
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
-        return headers
     
     # Semantic Memory Methods
     

--- a/sdk/python/soorma/memory/client.py
+++ b/sdk/python/soorma/memory/client.py
@@ -9,6 +9,8 @@ framework with four types of memory:
 - Working Memory: Plan-scoped shared state for multi-agent collaboration
 """
 
+import os
+
 from typing import Any, Dict, List, Optional
 import httpx
 
@@ -38,7 +40,6 @@ from soorma_common.models import (
     SessionCreate,
     SessionSummary,
 )
-from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 
 
 class MemoryServiceClient:
@@ -74,7 +75,7 @@ class MemoryServiceClient:
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self.platform_tenant_id = platform_tenant_id or DEFAULT_PLATFORM_TENANT_ID
+        self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
         self.auth_token = auth_token
         self.auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)

--- a/sdk/python/soorma/registry/client.py
+++ b/sdk/python/soorma/registry/client.py
@@ -2,7 +2,6 @@
 Client library for interacting with the Registry Service.
 """
 import logging
-import os
 from typing import List, Optional
 
 import httpx
@@ -32,9 +31,8 @@ class RegistryClient:
     Client for interacting with the Registry Service API.
 
     Authentication Model:
-        Registry is still on the Tier-1 developer-tenant header contract.
-        Bearer auth can be used when explicitly configured, but the default
-        SDK fallback remains `X-Tenant-ID` using the developer tenant.
+        Registry uses explicit bearer-token transport. Callers must provide
+        either an auth token or an auth token provider.
     """
 
     def __init__(
@@ -43,7 +41,6 @@ class RegistryClient:
             timeout: float = 30.0,
             auth_token: Optional[str] = None,
             auth_token_provider: Optional[AuthTokenProvider] = None,
-            developer_tenant_id: Optional[str] = None,
     ):
         """
         Initialize the registry client.
@@ -54,9 +51,8 @@ class RegistryClient:
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self._auth_token = os.getenv("SOORMA_AUTH_TOKEN") if auth_token is None else auth_token
+        self._auth_token = auth_token
         self._auth_token_provider = auth_token_provider
-        self._developer_tenant_id = developer_tenant_id or os.getenv("SOORMA_DEVELOPER_TENANT_ID")
         self._client = httpx.AsyncClient(timeout=timeout)
 
     def set_auth_token(self, auth_token: Optional[str]) -> None:
@@ -72,8 +68,6 @@ class RegistryClient:
         token = await resolve_auth_token(self._auth_token, self._auth_token_provider)
         if token:
             return {"Authorization": f"Bearer {token}"}
-        if self._developer_tenant_id:
-            return {"X-Tenant-ID": self._developer_tenant_id}
         return {}
     
     async def close(self):
@@ -250,8 +244,7 @@ class RegistryClient:
         """
         Deregister (delete) an agent from the registry.
 
-        Must include auth headers (X-Tenant-ID) — the agent belongs to the
-        developer tenant and can only be removed within that tenant scope.
+        Must include explicit auth — registry requests are JWT-authenticated.
 
         Args:
             agent_id: ID of the agent to deregister

--- a/sdk/python/soorma/registry/client.py
+++ b/sdk/python/soorma/registry/client.py
@@ -32,9 +32,9 @@ class RegistryClient:
     Client for interacting with the Registry Service API.
 
     Authentication Model:
-        Registry uses bearer-token transport during JWT cutover. Server-side
-        platform tenant resolution comes from validated JWT claims rather than
-        legacy tenant headers projected by the SDK.
+        Registry is still on the Tier-1 developer-tenant header contract.
+        Bearer auth can be used when explicitly configured, but the default
+        SDK fallback remains `X-Tenant-ID` using the developer tenant.
     """
 
     def __init__(
@@ -43,6 +43,7 @@ class RegistryClient:
             timeout: float = 30.0,
             auth_token: Optional[str] = None,
             auth_token_provider: Optional[AuthTokenProvider] = None,
+            developer_tenant_id: Optional[str] = None,
     ):
         """
         Initialize the registry client.
@@ -53,8 +54,9 @@ class RegistryClient:
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self._auth_token = auth_token or os.getenv("SOORMA_AUTH_TOKEN")
+        self._auth_token = os.getenv("SOORMA_AUTH_TOKEN") if auth_token is None else auth_token
         self._auth_token_provider = auth_token_provider
+        self._developer_tenant_id = developer_tenant_id or os.getenv("SOORMA_DEVELOPER_TENANT_ID")
         self._client = httpx.AsyncClient(timeout=timeout)
 
     def set_auth_token(self, auth_token: Optional[str]) -> None:
@@ -68,9 +70,11 @@ class RegistryClient:
     async def _build_auth_headers(self) -> dict[str, str]:
         """Build auth headers for registry-service calls."""
         token = await resolve_auth_token(self._auth_token, self._auth_token_provider)
-        if not token:
-            return {}
-        return {"Authorization": f"Bearer {token}"}
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+        if self._developer_tenant_id:
+            return {"X-Tenant-ID": self._developer_tenant_id}
+        return {}
     
     async def close(self):
         """Close the HTTP client."""

--- a/sdk/python/soorma/registry/client.py
+++ b/sdk/python/soorma/registry/client.py
@@ -4,7 +4,10 @@ Client library for interacting with the Registry Service.
 import logging
 import os
 from typing import List, Optional
+
 import httpx
+
+from soorma.auth import AuthTokenProvider, resolve_auth_token
 from soorma_common import (
     EventDefinition,
     EventRegistrationRequest,
@@ -29,28 +32,20 @@ class RegistryClient:
     Client for interacting with the Registry Service API.
 
     Authentication Model:
-      Registry Service is scoped to the **developer's own tenant** — not to any
-      end-user session. The developer tenant UUID is read from the environment at
-      construction time and sent as X-Tenant-ID on every request.
-
-      Conceptual model (see ARCHITECTURE_PATTERNS.md Section 1):
-        - SOORMA_DEVELOPER_TENANT_ID  → X-Tenant-ID  (this client)
-        - User Tenant / User ID       → from event envelope (Memory, Tracker, Bus)
-
-    TODO: Replace env-var placeholder with API key / machine token once that
-    auth flow is implemented (v0.8.0+).
+        Registry uses bearer-token transport during JWT cutover. Server-side
+        platform tenant resolution comes from validated JWT claims rather than
+        legacy tenant headers projected by the SDK.
     """
 
-    def __init__(self, base_url: str, timeout: float = 30.0):
+    def __init__(
+            self,
+            base_url: str,
+            timeout: float = 30.0,
+            auth_token: Optional[str] = None,
+            auth_token_provider: Optional[AuthTokenProvider] = None,
+    ):
         """
         Initialize the registry client.
-
-        The developer tenant UUID is read from SOORMA_DEVELOPER_TENANT_ID at
-        construction time. This represents the developer's own identity for
-        startup registration — not the identity of any end-user or session.
-
-        Falls back to the sentinel UUID 00000000-... for local development when
-        the env var is not set.
 
         Args:
             base_url: Base URL of the registry service (e.g., "http://localhost:8081")
@@ -58,14 +53,24 @@ class RegistryClient:
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        # Developer deployment identity — placeholder until API key auth is available.
-        # SOORMA_DEVELOPER_TENANT_ID identifies whose agents/events are being registered.
-        _developer_tenant_id = os.getenv(
-            "SOORMA_DEVELOPER_TENANT_ID",
-            "00000000-0000-0000-0000-000000000000"
-        )
-        self._auth_headers = {"X-Tenant-ID": _developer_tenant_id}
+        self._auth_token = auth_token or os.getenv("SOORMA_AUTH_TOKEN")
+        self._auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)
+
+    def set_auth_token(self, auth_token: Optional[str]) -> None:
+        """Inject or replace bearer token for registry-service requests."""
+        self._auth_token = auth_token
+
+    def set_auth_token_provider(self, auth_token_provider: Optional[AuthTokenProvider]) -> None:
+        """Inject or replace bearer token provider for registry-service requests."""
+        self._auth_token_provider = auth_token_provider
+
+    async def _build_auth_headers(self) -> dict[str, str]:
+        """Build auth headers for registry-service calls."""
+        token = await resolve_auth_token(self._auth_token, self._auth_token_provider)
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}"}
     
     async def close(self):
         """Close the HTTP client."""
@@ -100,7 +105,7 @@ class RegistryClient:
         response = await self._client.post(
             f"{self.base_url}/v1/events",
             json=request_json,
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         logger.info(f"[RegistryClient] Event {event.event_name} registered successfully")
@@ -120,7 +125,7 @@ class RegistryClient:
         response = await self._client.get(
             f"{self.base_url}/v1/events",
             params={"event_name": event_name},
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         result = EventQueryResponse.model_validate(response.json())
@@ -141,7 +146,7 @@ class RegistryClient:
         response = await self._client.get(
             f"{self.base_url}/v1/events",
             params={"topic": topic},
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         result = EventQueryResponse.model_validate(response.json())
@@ -157,7 +162,7 @@ class RegistryClient:
         """
         response = await self._client.get(
             f"{self.base_url}/v1/events",
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         result = EventQueryResponse.model_validate(response.json())
@@ -179,7 +184,7 @@ class RegistryClient:
         response = await self._client.post(
             f"{self.base_url}/v1/agents",
             json=request.model_dump(by_alias=True),
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         return AgentRegistrationResponse.model_validate(response.json())
@@ -197,7 +202,7 @@ class RegistryClient:
         response = await self._client.get(
             f"{self.base_url}/v1/agents",
             params={"agent_id": agent_id},
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         result = AgentQueryResponse.model_validate(response.json())
@@ -231,7 +236,7 @@ class RegistryClient:
         response = await self._client.get(
             f"{self.base_url}/v1/agents",
             params=params,
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         response.raise_for_status()
         result = AgentQueryResponse.model_validate(response.json())
@@ -252,7 +257,7 @@ class RegistryClient:
         """
         response = await self._client.delete(
             f"{self.base_url}/v1/agents/{agent_id}",
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         if response.status_code == 404:
             return False
@@ -274,7 +279,7 @@ class RegistryClient:
         """
         response = await self._client.put(
             f"{self.base_url}/v1/agents/{agent_id}/heartbeat",
-            headers=self._auth_headers
+            headers=await self._build_auth_headers()
         )
         return response.status_code == 200
 
@@ -294,7 +299,7 @@ class RegistryClient:
         response = await self._client.post(
             f"{self.base_url}/v1/schemas",
             json=request.model_dump(by_alias=True),
-            headers=self._auth_headers,
+            headers=await self._build_auth_headers(),
         )
         response.raise_for_status()
         return PayloadSchemaResponse.model_validate(response.json())
@@ -318,7 +323,7 @@ class RegistryClient:
             url = f"{self.base_url}/v1/schemas/{schema_name}/versions/{version}"
         else:
             url = f"{self.base_url}/v1/schemas/{schema_name}"
-        response = await self._client.get(url, headers=self._auth_headers)
+        response = await self._client.get(url, headers=await self._build_auth_headers())
         if response.status_code == 404:
             return None
         response.raise_for_status()
@@ -343,7 +348,7 @@ class RegistryClient:
         response = await self._client.get(
             f"{self.base_url}/v1/schemas",
             params=params,
-            headers=self._auth_headers,
+            headers=await self._build_auth_headers(),
         )
         response.raise_for_status()
         result = PayloadSchemaListResponse.model_validate(response.json())
@@ -398,7 +403,7 @@ class RegistryClient:
         response = await self._client.get(
             f"{self.base_url}/v1/agents/discover",
             params=params,
-            headers=self._auth_headers,
+            headers=await self._build_auth_headers(),
         )
         response.raise_for_status()
         result = AgentQueryResponse.model_validate(response.json())
@@ -437,7 +442,7 @@ class RegistryClient:
         # filter, so we apply it client-side below.
         response = await self._client.get(
             f"{self.base_url}/v1/agents/discover",
-            headers=self._auth_headers,
+            headers=await self._build_auth_headers(),
         )
         response.raise_for_status()
         result = AgentQueryResponse.model_validate(response.json())

--- a/sdk/python/soorma/tracker/client.py
+++ b/sdk/python/soorma/tracker/client.py
@@ -1,7 +1,5 @@
 """TrackerServiceClient - Low-level HTTP client for Tracker Service (Layer 1)."""
 
-import os
-
 from typing import Dict, List, Optional
 
 import httpx
@@ -28,10 +26,14 @@ class TrackerServiceClient:
         auth_token: Optional[str] = None,
         auth_token_provider: Optional[AuthTokenProvider] = None,
     ):
-        """Initialize the Tracker Service client."""
+        """Initialize the Tracker Service client.
+
+        platform_tenant_id is retained as explicit compatibility-only state and
+        is not projected on the active bearer-auth path.
+        """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
+        self.platform_tenant_id = platform_tenant_id
         self.auth_token = auth_token
         self.auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)

--- a/sdk/python/soorma/tracker/client.py
+++ b/sdk/python/soorma/tracker/client.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 
 import httpx
 
+from soorma.auth import AuthTokenProvider, resolve_auth_token
 from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 from soorma_common.tracker import (
     AgentMetrics,
@@ -24,12 +25,14 @@ class TrackerServiceClient:
         timeout: float = 30.0,
         platform_tenant_id: Optional[str] = None,
         auth_token: Optional[str] = None,
+        auth_token_provider: Optional[AuthTokenProvider] = None,
     ):
         """Initialize the Tracker Service client."""
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.platform_tenant_id = platform_tenant_id or DEFAULT_PLATFORM_TENANT_ID
         self.auth_token = auth_token
+        self.auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)
 
     async def close(self):
@@ -44,23 +47,16 @@ class TrackerServiceClient:
         """Async context manager exit."""
         await self.close()
 
-    def _build_identity_headers(
+    async def _build_identity_headers(
         self,
         service_tenant_id: str,
         service_user_id: str,
     ) -> Dict[str, str]:
         """Build required identity headers for Tracker Service requests."""
-        if self.auth_token:
-            return {"Authorization": f"Bearer {self.auth_token}"}
-
-        if not service_tenant_id or not service_user_id:
-            raise ValueError("service_tenant_id and service_user_id are required")
-
-        return {
-            "X-Tenant-ID": self.platform_tenant_id,
-            "X-Service-Tenant-ID": service_tenant_id,
-            "X-User-ID": service_user_id,
-        }
+        token = await resolve_auth_token(self.auth_token, self.auth_token_provider)
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}"}
 
     async def get_plan_progress(
         self,
@@ -72,7 +68,7 @@ class TrackerServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/tracker/plans/{plan_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return PlanProgress.model_validate(response.json())
@@ -91,7 +87,7 @@ class TrackerServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/tracker/plans/{plan_id}/actions",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return [TaskExecution.model_validate(task) for task in response.json()]
@@ -110,7 +106,7 @@ class TrackerServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/tracker/plans/{plan_id}/timeline",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return EventTimeline.model_validate(response.json())
@@ -131,7 +127,7 @@ class TrackerServiceClient:
             response = await self._client.get(
                 f"{self.base_url}/v1/tracker/metrics",
                 params={"agent_id": agent_id, "period": period},
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return AgentMetrics.model_validate(response.json())
@@ -149,7 +145,7 @@ class TrackerServiceClient:
         """Get child plans for a given plan."""
         response = await self._client.get(
             f"{self.base_url}/v1/tracker/plans/{plan_id}/sub-plans",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return [PlanExecution.model_validate(plan) for plan in response.json()]
@@ -163,7 +159,7 @@ class TrackerServiceClient:
         """Get all plans in a conversation session."""
         response = await self._client.get(
             f"{self.base_url}/v1/tracker/sessions/{session_id}/plans",
-            headers=self._build_identity_headers(service_tenant_id, service_user_id),
+            headers=await self._build_identity_headers(service_tenant_id, service_user_id),
         )
         response.raise_for_status()
         return [PlanExecution.model_validate(plan) for plan in response.json()]
@@ -178,7 +174,7 @@ class TrackerServiceClient:
         try:
             response = await self._client.get(
                 f"{self.base_url}/v1/tracker/delegation-groups/{group_id}",
-                headers=self._build_identity_headers(service_tenant_id, service_user_id),
+                headers=await self._build_identity_headers(service_tenant_id, service_user_id),
             )
             response.raise_for_status()
             return DelegationGroup.model_validate(response.json())

--- a/sdk/python/soorma/tracker/client.py
+++ b/sdk/python/soorma/tracker/client.py
@@ -1,11 +1,12 @@
 """TrackerServiceClient - Low-level HTTP client for Tracker Service (Layer 1)."""
 
+import os
+
 from typing import Dict, List, Optional
 
 import httpx
 
 from soorma.auth import AuthTokenProvider, resolve_auth_token
-from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 from soorma_common.tracker import (
     AgentMetrics,
     DelegationGroup,
@@ -30,7 +31,7 @@ class TrackerServiceClient:
         """Initialize the Tracker Service client."""
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self.platform_tenant_id = platform_tenant_id or DEFAULT_PLATFORM_TENANT_ID
+        self.platform_tenant_id = platform_tenant_id or os.getenv("SOORMA_PLATFORM_TENANT_ID") or None
         self.auth_token = auth_token
         self.auth_token_provider = auth_token_provider
         self._client = httpx.AsyncClient(timeout=timeout)

--- a/sdk/python/soorma/tracker/client.py
+++ b/sdk/python/soorma/tracker/client.py
@@ -50,17 +50,17 @@ class TrackerServiceClient:
         service_user_id: str,
     ) -> Dict[str, str]:
         """Build required identity headers for Tracker Service requests."""
+        if self.auth_token:
+            return {"Authorization": f"Bearer {self.auth_token}"}
+
         if not service_tenant_id or not service_user_id:
             raise ValueError("service_tenant_id and service_user_id are required")
 
-        headers = {
+        return {
             "X-Tenant-ID": self.platform_tenant_id,
             "X-Service-Tenant-ID": service_tenant_id,
             "X-User-ID": service_user_id,
         }
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
-        return headers
 
     async def get_plan_progress(
         self,

--- a/sdk/python/tests/cli/test_dev.py
+++ b/sdk/python/tests/cli/test_dev.py
@@ -1,5 +1,6 @@
 """Tests for the dev command."""
 
+import json
 import os
 import subprocess
 import tempfile
@@ -15,12 +16,18 @@ from soorma.cli.commands.dev import (
     BOOTSTRAP_OUTCOME_CREATED,
     BOOTSTRAP_OUTCOME_FAILED_DRIFT,
     BOOTSTRAP_OUTCOME_REUSED,
+    DEV_IDENTITY_ACTIVE_SIGNING_KID,
+    DEV_IDENTITY_DIR_NAME,
+    DEV_IDENTITY_JWKS_FILE,
+    DEV_IDENTITY_PRIVATE_KEY_FILE,
+    DEV_IDENTITY_PUBLIC_KEY_FILE,
     SERVICE_DEFINITIONS,
     build_bootstrap_fingerprint,
     check_service_image,
     determine_bootstrap_outcome,
     find_soorma_core_root,
     get_soorma_dir,
+    resolve_dev_identity_bootstrap_config,
     write_bootstrap_state,
 )
 
@@ -248,6 +255,110 @@ class TestBootstrapState:
         assert '"fingerprint": "fp-abc"' in payload
         assert '"registry_port": "8081"' in payload
         assert '"updated_at": ' in payload
+
+
+class TestDevIdentityBootstrapConfig:
+    """Tests for deterministic RS256 local identity bootstrap config."""
+
+    def test_defaults_generate_persisted_rs256_keyrings_and_jwks(self, monkeypatch, tmp_path):
+        """Default bootstrap config should generate and persist RS256 material under .soorma."""
+        for env_var in (
+            "IDENTITY_SIGNING_ALGORITHM",
+            "IDENTITY_ACTIVE_SIGNING_KID",
+            "IDENTITY_SIGNING_PRIVATE_KEYRING_JSON",
+            "IDENTITY_SIGNING_PUBLIC_KEYRING_JSON",
+            "IDENTITY_JWKS_PUBLICATION_JSON",
+            "IDENTITY_VERIFIER_JWKS_JSON",
+            "SOORMA_AUTH_JWKS_JSON",
+            "SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+
+        soorma_dir = tmp_path / ".soorma"
+        config = resolve_dev_identity_bootstrap_config(soorma_dir)
+
+        assert config["identity_signing_algorithm"] == "RS256"
+        assert config["identity_active_signing_kid"] == DEV_IDENTITY_ACTIVE_SIGNING_KID
+
+        identity_dir = soorma_dir / DEV_IDENTITY_DIR_NAME
+        assert (identity_dir / DEV_IDENTITY_PRIVATE_KEY_FILE).exists()
+        assert (identity_dir / DEV_IDENTITY_PUBLIC_KEY_FILE).exists()
+        assert (identity_dir / DEV_IDENTITY_JWKS_FILE).exists()
+
+        private_ring = json.loads(config["identity_signing_private_keyring_json"])
+        public_ring = json.loads(config["identity_signing_public_keyring_json"])
+        published_jwks = json.loads(config["identity_jwks_publication_json"])
+        verifier_jwks = json.loads(config["identity_verifier_jwks_json"])
+        auth_jwks = json.loads(config["soorma_auth_jwks_json"])
+        auth_public_keys = json.loads(config["soorma_auth_jwt_public_keys_json"])
+
+        assert DEV_IDENTITY_ACTIVE_SIGNING_KID in private_ring
+        assert DEV_IDENTITY_ACTIVE_SIGNING_KID in public_ring
+        assert private_ring[DEV_IDENTITY_ACTIVE_SIGNING_KID].startswith("-----BEGIN PRIVATE KEY-----")
+        assert public_ring[DEV_IDENTITY_ACTIVE_SIGNING_KID].startswith("-----BEGIN PUBLIC KEY-----")
+        assert published_jwks["keys"][0]["kid"] == DEV_IDENTITY_ACTIVE_SIGNING_KID
+        assert published_jwks == verifier_jwks == auth_jwks
+        assert auth_public_keys[DEV_IDENTITY_ACTIVE_SIGNING_KID].startswith("-----BEGIN PUBLIC KEY-----")
+
+        second_config = resolve_dev_identity_bootstrap_config(soorma_dir)
+        assert second_config == config
+
+    def test_missing_persisted_private_key_regenerates_material(self, monkeypatch, tmp_path):
+        """Deleting persisted key files should force regeneration on the next bootstrap."""
+        for env_var in (
+            "IDENTITY_SIGNING_ALGORITHM",
+            "IDENTITY_ACTIVE_SIGNING_KID",
+            "IDENTITY_SIGNING_PRIVATE_KEYRING_JSON",
+            "IDENTITY_SIGNING_PUBLIC_KEYRING_JSON",
+            "IDENTITY_JWKS_PUBLICATION_JSON",
+            "IDENTITY_VERIFIER_JWKS_JSON",
+            "SOORMA_AUTH_JWKS_JSON",
+            "SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+
+        soorma_dir = tmp_path / ".soorma"
+        first_config = resolve_dev_identity_bootstrap_config(soorma_dir)
+
+        identity_dir = soorma_dir / DEV_IDENTITY_DIR_NAME
+        (identity_dir / DEV_IDENTITY_PRIVATE_KEY_FILE).unlink()
+        (identity_dir / DEV_IDENTITY_PUBLIC_KEY_FILE).unlink()
+        (identity_dir / DEV_IDENTITY_JWKS_FILE).unlink()
+
+        second_config = resolve_dev_identity_bootstrap_config(soorma_dir)
+
+        assert second_config["identity_active_signing_kid"] == DEV_IDENTITY_ACTIVE_SIGNING_KID
+        assert (
+            second_config["identity_signing_private_keyring_json"]
+            != first_config["identity_signing_private_keyring_json"]
+        )
+        assert (
+            second_config["identity_signing_public_keyring_json"]
+            != first_config["identity_signing_public_keyring_json"]
+        )
+
+    def test_explicit_overrides_take_precedence(self, monkeypatch, tmp_path):
+        """Explicit env overrides should win over deterministic defaults."""
+        monkeypatch.setenv("IDENTITY_SIGNING_ALGORITHM", "RS256")
+        monkeypatch.setenv("IDENTITY_ACTIVE_SIGNING_KID", "override-kid")
+        monkeypatch.setenv("IDENTITY_SIGNING_PRIVATE_KEYRING_JSON", '{"override-kid":"private"}')
+        monkeypatch.setenv("IDENTITY_SIGNING_PUBLIC_KEYRING_JSON", '{"override-kid":"public"}')
+        monkeypatch.setenv("IDENTITY_JWKS_PUBLICATION_JSON", '{"keys":[{"kid":"override-kid"}]}')
+        monkeypatch.setenv("IDENTITY_VERIFIER_JWKS_JSON", '{"keys":[{"kid":"verify-kid"}]}')
+        monkeypatch.setenv("SOORMA_AUTH_JWKS_JSON", '{"keys":[{"kid":"auth-kid"}]}')
+        monkeypatch.setenv("SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON", '{"override-kid":"auth-public"}')
+
+        soorma_dir = tmp_path / ".soorma"
+        config = resolve_dev_identity_bootstrap_config(soorma_dir)
+
+        assert config["identity_active_signing_kid"] == "override-kid"
+        assert json.loads(config["identity_signing_private_keyring_json"]) == {"override-kid": "private"}
+        assert json.loads(config["identity_signing_public_keyring_json"]) == {"override-kid": "public"}
+        assert json.loads(config["identity_jwks_publication_json"]) == {"keys": [{"kid": "override-kid"}]}
+        assert json.loads(config["identity_verifier_jwks_json"]) == {"keys": [{"kid": "verify-kid"}]}
+        assert json.loads(config["soorma_auth_jwks_json"]) == {"keys": [{"kid": "auth-kid"}]}
+        assert json.loads(config["soorma_auth_jwt_public_keys_json"]) == {"override-kid": "auth-public"}
+        assert not (soorma_dir / DEV_IDENTITY_DIR_NAME).exists()
 
 
 class TestDevCommand:

--- a/sdk/python/tests/integration/conftest.py
+++ b/sdk/python/tests/integration/conftest.py
@@ -12,9 +12,11 @@ All tests in this package use:
 
 import asyncio
 import os
+import time
 from typing import Generator
 
 import httpx
+import jwt
 import pytest
 from sqlalchemy import create_engine as _sync_create_engine, text
 
@@ -27,7 +29,7 @@ _TEST_DB = "/tmp/soorma_integration_test.db"
 os.environ.setdefault("DATABASE_URL", f"sqlite+aiosqlite:///{_TEST_DB}")
 os.environ.setdefault("SYNC_DATABASE_URL", f"sqlite:///{_TEST_DB}")
 os.environ.setdefault("IS_LOCAL_TESTING", "true")
-os.environ.setdefault("SOORMA_DEVELOPER_TENANT_ID", "00000000-0000-0000-0000-000000000001")
+os.environ.setdefault("SOORMA_AUTH_JWT_SECRET", "sdk-integration-secret")
 
 # ---------------------------------------------------------------------------
 # 2. Service imports — safe now that env vars are in place
@@ -125,24 +127,38 @@ def make_registry_client(tenant_id: str = TENANT_A) -> RegistryClient:
     """Return a RegistryClient that drives the in-process Registry via ASGITransport.
 
     The underlying httpx.AsyncClient is replaced with one that routes all
-    requests directly through the ASGI app (no TCP socket needed).  The
-    auth headers are also overridden so each test can choose its tenant.
+    requests directly through the ASGI app (no TCP socket needed). Requests
+    authenticate using an explicit per-test JWT provider.
 
     Args:
-        tenant_id: X-Tenant-ID header value to use for all requests.
+        tenant_id: Platform tenant ID to encode into the JWT claims.
 
     Returns:
         Configured RegistryClient ready for async use.
     """
+    def auth_token_provider() -> str:
+        now = int(time.time())
+        return jwt.encode(
+            {
+                "tenant_id": tenant_id,
+                "platform_tenant_id": tenant_id,
+                "principal_id": f"principal-{tenant_id}",
+                "principal_type": "developer",
+                "roles": ["developer"],
+                "sub": f"principal-{tenant_id}",
+                "exp": now + 300,
+            },
+            os.environ["SOORMA_AUTH_JWT_SECRET"],
+            algorithm="HS256",
+        )
+
     client = RegistryClient(
         base_url="http://test-registry",
-        auth_token="",
-        developer_tenant_id=tenant_id,
+        auth_token_provider=auth_token_provider,
     )
     # Swap the default HTTP transport for an in-process ASGI transport
     client._client = httpx.AsyncClient(
         transport=httpx.ASGITransport(app=_registry_app),
         base_url="http://test-registry",
-        headers={"X-Identity-Admin-Key": "dev-identity-admin"},
     )
     return client

--- a/sdk/python/tests/integration/conftest.py
+++ b/sdk/python/tests/integration/conftest.py
@@ -134,12 +134,15 @@ def make_registry_client(tenant_id: str = TENANT_A) -> RegistryClient:
     Returns:
         Configured RegistryClient ready for async use.
     """
-    client = RegistryClient(base_url="http://test-registry")
+    client = RegistryClient(
+        base_url="http://test-registry",
+        auth_token="",
+        developer_tenant_id=tenant_id,
+    )
     # Swap the default HTTP transport for an in-process ASGI transport
     client._client = httpx.AsyncClient(
         transport=httpx.ASGITransport(app=_registry_app),
         base_url="http://test-registry",
+        headers={"X-Identity-Admin-Key": "dev-identity-admin"},
     )
-    # Ensure the correct tenant header is sent on every request
-    client._auth_headers = {"X-Tenant-ID": tenant_id}
     return client

--- a/sdk/python/tests/test_agents.py
+++ b/sdk/python/tests/test_agents.py
@@ -270,6 +270,15 @@ class TestPlatformContext:
             assert context.memory.base_url == "http://memory:8083"
             assert context.tracker.base_url == "http://tracker:8084"
 
+    def test_context_from_env_accepts_explicit_auth(self):
+        """from_env() should use explicitly supplied auth instead of env fallback."""
+        from soorma import PlatformContext
+
+        context = PlatformContext.from_env(auth_token="jwt-token-value")
+
+        assert context.memory.auth_token == "jwt-token-value"
+        assert context.tracker.auth_token == "jwt-token-value"
+
     def test_set_auth_token_propagates_to_wrappers(self):
         """Injected bearer token should be available to memory/tracker wrappers."""
         from soorma import PlatformContext

--- a/sdk/python/tests/test_bus_client.py
+++ b/sdk/python/tests/test_bus_client.py
@@ -225,6 +225,14 @@ class TestBusClientConvenienceMethods:
         assert call_kwargs["topic"] == "business-facts"
         assert call_kwargs["event_type"] == "order.placed"
 
+    def test_set_auth_token_delegates_to_event_client(self, bus_client):
+        """set_auth_token() should forward the token to the underlying EventClient."""
+        bus_client.event_client.set_auth_token = MagicMock()
+
+        bus_client.set_auth_token("jwt-token")
+
+        bus_client.event_client.set_auth_token.assert_called_once_with("jwt-token")
+
 
 class TestBusClientEventCreation:
     """Tests for create_child_request(), create_response() utilities."""

--- a/sdk/python/tests/test_context_wrappers.py
+++ b/sdk/python/tests/test_context_wrappers.py
@@ -360,10 +360,7 @@ class TestMemoryClientWrapper:
             # Verify
             assert client == mock_instance
             assert wrapper._client == mock_instance
-            mock_client_class.assert_called_once_with(
-                base_url="http://memory:8002",
-                auth_token=None,
-            )
+            mock_client_class.assert_called_once_with(base_url="http://memory:8002")
             mock_instance.health.assert_called_once()
     
     @pytest.mark.asyncio

--- a/sdk/python/tests/test_event_client_registration.py
+++ b/sdk/python/tests/test_event_client_registration.py
@@ -283,9 +283,8 @@ class TestEventClientAuthHeaders:
     """Tests for event-service auth header construction."""
 
     @pytest.mark.asyncio
-    async def test_build_auth_headers_without_token_uses_platform_tenant_only(self, monkeypatch):
+    async def test_build_auth_headers_without_token_are_empty(self):
         """Auth headers should be empty when no bearer token is configured."""
-        monkeypatch.delenv("SOORMA_AUTH_TOKEN", raising=False)
         client = EventClient(agent_id="test-client", platform_tenant_id="tenant-platform")
 
         headers = await client._build_auth_headers()

--- a/sdk/python/tests/test_event_client_registration.py
+++ b/sdk/python/tests/test_event_client_registration.py
@@ -256,6 +256,56 @@ class TestEventClientPublishResponseSchemaName:
             call_json = mock_http.post.call_args[1]["json"]
             assert "response_schema_name" not in call_json["event"]
 
+    @pytest.mark.asyncio
+    async def test_publish_includes_authorization_header_when_auth_token_present(self):
+        """EventClient should send bearer auth on publish when configured."""
+        client = EventClient(agent_id="test-client", auth_token="jwt-token")
+        with patch.object(client, "_ensure_http_client", new_callable=AsyncMock), patch.object(
+            client, "_http_client", create=True
+        ) as mock_http:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"id": "evt-123"}
+            mock_http.post = AsyncMock(return_value=mock_response)
+
+            await client.publish(
+                event_type="research.goal",
+                topic=EventTopic.ACTION_REQUESTS,
+                data={"description": "test"},
+            )
+
+            headers = mock_http.post.call_args.kwargs["headers"]
+            assert headers["Authorization"] == "Bearer jwt-token"
+            assert "X-Tenant-ID" not in headers
+
+
+class TestEventClientAuthHeaders:
+    """Tests for event-service auth header construction."""
+
+    @pytest.mark.asyncio
+    async def test_build_auth_headers_without_token_uses_platform_tenant_only(self, monkeypatch):
+        """Auth headers should be empty when no bearer token is configured."""
+        monkeypatch.delenv("SOORMA_AUTH_TOKEN", raising=False)
+        client = EventClient(agent_id="test-client", platform_tenant_id="tenant-platform")
+
+        headers = await client._build_auth_headers()
+
+        assert headers == {}
+
+    @pytest.mark.asyncio
+    async def test_build_auth_headers_with_token_includes_authorization(self):
+        """Auth headers should include Authorization when auth_token is set."""
+        client = EventClient(
+            agent_id="test-client",
+            platform_tenant_id="tenant-platform",
+            auth_token="jwt-token",
+        )
+
+        headers = await client._build_auth_headers()
+
+        assert "X-Tenant-ID" not in headers
+        assert headers["Authorization"] == "Bearer jwt-token"
+
 
 class TestBusClientResponseSchemaName:
     """BusClient.publish() passes response_schema_name through to EventClient."""

--- a/sdk/python/tests/test_example_auth_bootstrap.py
+++ b/sdk/python/tests/test_example_auth_bootstrap.py
@@ -1,0 +1,136 @@
+"""Tests for shared example JWT bootstrap persistence helpers."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from soorma_common.models import OnboardingResponse, TokenIssueResponse
+
+
+EXAMPLE_NAME = "01-hello-world"
+SHARED_AUTH_PATH = Path(__file__).resolve().parents[3] / "examples" / "shared" / "auth.py"
+
+
+@pytest.fixture
+def shared_auth_module():
+    """Load the shared example auth helper as a module for direct testing."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("example_shared_auth", SHARED_AUTH_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_ensure_example_auth_token_bootstraps_once_and_persists(shared_auth_module, tmp_path, monkeypatch):
+    """Helper should persist onboarding metadata and reuse a cached provider token."""
+    repo_root = tmp_path / "repo"
+    examples_dir = repo_root / "examples" / "01-hello-world"
+    sdk_dir = repo_root / "sdk"
+    examples_dir.mkdir(parents=True)
+    sdk_dir.mkdir(parents=True)
+    script_path = examples_dir / "worker.py"
+    script_path.write_text("# placeholder\n")
+
+    mock_identity_client = AsyncMock()
+    mock_identity_client.onboard_tenant = AsyncMock(
+        return_value=OnboardingResponse(
+            tenant_domain_id="td-1",
+            platform_tenant_id="pt-1",
+            bootstrap_admin_principal_id="pr-1",
+            status="created",
+        )
+    )
+    mock_identity_client.issue_token = AsyncMock(
+        return_value=TokenIssueResponse(token="jwt-token", token_type="Bearer")
+    )
+    mock_identity_client.__aenter__.return_value = mock_identity_client
+    mock_identity_client.__aexit__.return_value = None
+
+    with patch.object(shared_auth_module, "IdentityServiceClient", return_value=mock_identity_client), patch.object(
+        shared_auth_module.jwt,
+        "decode",
+        return_value={"exp": 4102444800},
+    ):
+        token = await shared_auth_module.ensure_example_auth_token(EXAMPLE_NAME, script_path)
+        second_token = await shared_auth_module.ensure_example_auth_token(EXAMPLE_NAME, script_path)
+
+    assert token == "jwt-token"
+    assert second_token == "jwt-token"
+    assert mock_identity_client.onboard_tenant.await_count == 1
+    assert mock_identity_client.issue_token.await_count == 2
+
+    bootstrap_file = repo_root / ".soorma" / shared_auth_module.bootstrap_filename(EXAMPLE_NAME)
+    payload = json.loads(bootstrap_file.read_text())
+    assert payload["platform_tenant_id"] == "pt-1"
+    assert payload["bootstrap_admin_principal_id"] == "pr-1"
+    assert shared_auth_module.os.environ["SOORMA_AUTH_TOKEN"] == "jwt-token"
+    assert shared_auth_module.os.environ["SOORMA_PLATFORM_TENANT_ID"] == "pt-1"
+
+
+@pytest.mark.asyncio
+async def test_build_example_token_provider_refreshes_when_cached_token_is_expired(
+    shared_auth_module, tmp_path
+):
+    """Provider should refresh cached JWTs once they are past the refresh window."""
+    repo_root = tmp_path / "repo"
+    examples_dir = repo_root / "examples" / "01-hello-world"
+    sdk_dir = repo_root / "sdk"
+    examples_dir.mkdir(parents=True)
+    sdk_dir.mkdir(parents=True)
+    script_path = examples_dir / "worker.py"
+    script_path.write_text("# placeholder\n")
+
+    mock_identity_client = AsyncMock()
+    mock_identity_client.onboard_tenant = AsyncMock(
+        return_value=OnboardingResponse(
+            tenant_domain_id="td-1",
+            platform_tenant_id="pt-1",
+            bootstrap_admin_principal_id="pr-1",
+            status="created",
+        )
+    )
+    mock_identity_client.issue_token = AsyncMock(
+        side_effect=[
+            TokenIssueResponse(token="fresh-token-1", token_type="Bearer"),
+            TokenIssueResponse(token="fresh-token", token_type="Bearer"),
+        ]
+    )
+    mock_identity_client.__aenter__.return_value = mock_identity_client
+    mock_identity_client.__aexit__.return_value = None
+
+    provider = shared_auth_module.build_example_token_provider(EXAMPLE_NAME, script_path)
+    provider._cached_token = "expired-token"
+
+    with patch.object(shared_auth_module, "IdentityServiceClient", return_value=mock_identity_client), patch.object(
+        shared_auth_module.jwt,
+        "decode",
+        side_effect=[{"exp": 1}, {"exp": 4102444800}],
+    ):
+        token = await provider.get_token()
+        refreshed_token = await provider.get_token(force_refresh=True)
+
+    assert token == "fresh-token-1"
+    assert refreshed_token == "fresh-token"
+    assert mock_identity_client.onboard_tenant.await_count == 1
+    assert mock_identity_client.issue_token.await_count == 2
+
+
+def test_load_bootstrap_payload_returns_none_for_invalid_json(shared_auth_module, tmp_path):
+    """Invalid persisted bootstrap payload should be ignored and regenerated."""
+    repo_root = tmp_path / "repo"
+    examples_dir = repo_root / "examples" / "01-hello-world"
+    sdk_dir = repo_root / "sdk"
+    examples_dir.mkdir(parents=True)
+    sdk_dir.mkdir(parents=True)
+    script_path = examples_dir / "worker.py"
+    script_path.write_text("# placeholder\n")
+    bootstrap_file = repo_root / ".soorma" / shared_auth_module.bootstrap_filename(EXAMPLE_NAME)
+    bootstrap_file.parent.mkdir(parents=True)
+    bootstrap_file.write_text("{invalid-json")
+
+    assert shared_auth_module.load_bootstrap_payload(EXAMPLE_NAME, script_path) is None

--- a/sdk/python/tests/test_example_auth_bootstrap.py
+++ b/sdk/python/tests/test_example_auth_bootstrap.py
@@ -48,6 +48,7 @@ async def test_ensure_example_auth_token_bootstraps_once_and_persists(shared_aut
     mock_identity_client.issue_token = AsyncMock(
         return_value=TokenIssueResponse(token="jwt-token", token_type="Bearer")
     )
+    mock_identity_client.set_platform_tenant_id = MagicMock()
     mock_identity_client.__aenter__.return_value = mock_identity_client
     mock_identity_client.__aexit__.return_value = None
 
@@ -63,6 +64,7 @@ async def test_ensure_example_auth_token_bootstraps_once_and_persists(shared_aut
     assert second_token == "jwt-token"
     assert mock_identity_client.onboard_tenant.await_count == 1
     assert mock_identity_client.issue_token.await_count == 2
+    mock_identity_client.set_platform_tenant_id.assert_called_with("pt-1")
 
     bootstrap_file = repo_root / ".soorma" / shared_auth_module.bootstrap_filename(EXAMPLE_NAME)
     payload = json.loads(bootstrap_file.read_text())
@@ -100,6 +102,7 @@ async def test_build_example_token_provider_refreshes_when_cached_token_is_expir
             TokenIssueResponse(token="fresh-token", token_type="Bearer"),
         ]
     )
+    mock_identity_client.set_platform_tenant_id = MagicMock()
     mock_identity_client.__aenter__.return_value = mock_identity_client
     mock_identity_client.__aexit__.return_value = None
 
@@ -118,6 +121,33 @@ async def test_build_example_token_provider_refreshes_when_cached_token_is_expir
     assert refreshed_token == "fresh-token"
     assert mock_identity_client.onboard_tenant.await_count == 1
     assert mock_identity_client.issue_token.await_count == 2
+    mock_identity_client.set_platform_tenant_id.assert_called_with("pt-1")
+
+
+@pytest.mark.asyncio
+async def test_build_example_token_provider_exposes_bootstrapped_ids(shared_auth_module, tmp_path):
+    """Provider should expose bootstrapped tenant and principal identifiers."""
+    repo_root = tmp_path / "repo"
+    examples_dir = repo_root / "examples" / "01-hello-world"
+    sdk_dir = repo_root / "sdk"
+    examples_dir.mkdir(parents=True)
+    sdk_dir.mkdir(parents=True)
+    script_path = examples_dir / "worker.py"
+    script_path.write_text("# placeholder\n")
+
+    provider = shared_auth_module.build_example_token_provider(EXAMPLE_NAME, script_path)
+    shared_auth_module.persist_bootstrap_payload(
+        EXAMPLE_NAME,
+        script_path,
+        {
+            "tenant_domain_id": "td-1",
+            "platform_tenant_id": "pt-1",
+            "bootstrap_admin_principal_id": "pr-1",
+        },
+    )
+
+    assert await provider.get_platform_tenant_id() == "pt-1"
+    assert await provider.get_bootstrap_admin_principal_id() == "pr-1"
 
 
 def test_load_bootstrap_payload_returns_none_for_invalid_json(shared_auth_module, tmp_path):

--- a/sdk/python/tests/test_identity_service_client.py
+++ b/sdk/python/tests/test_identity_service_client.py
@@ -44,16 +44,11 @@ class TestIdentityServiceClientContracts:
         identity_client._client.post.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_issue_token_uses_jwt_authorization_when_configured(
+    async def test_issue_token_uses_admin_headers_when_platform_tenant_is_bound(
         self,
         identity_client: IdentityServiceClient,
-        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Client should send canonical outbound JWT auth when JWT config is present."""
-        monkeypatch.setenv("SOORMA_AUTH_JWT_SECRET", "test-secret")
-        monkeypatch.setenv("SOORMA_AUTH_JWT_ISSUER", "soorma-identity-service")
-        monkeypatch.setenv("SOORMA_AUTH_JWT_AUDIENCE", "soorma-services")
-        monkeypatch.delenv("SOORMA_IDENTITY_INCLUDE_LEGACY_ALIAS", raising=False)
+        """Client should send bound platform tenant plus admin key when available."""
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -65,6 +60,7 @@ class TestIdentityServiceClientContracts:
 
         identity_client._client = AsyncMock()
         identity_client._client.post = AsyncMock(return_value=mock_response)
+        identity_client.set_platform_tenant_id("platform-tenant-1")
 
         await identity_client.issue_token(
             payload=TokenIssueRequest(
@@ -78,19 +74,16 @@ class TestIdentityServiceClientContracts:
         headers = identity_client._client.post.call_args.kwargs["headers"]
         assert headers["X-Tenant-ID"] == identity_client.platform_tenant_id
         assert headers["X-Identity-Admin-Key"] == identity_client.admin_api_key
-        assert headers["Authorization"].startswith("Bearer ")
+        assert "Authorization" not in headers
         assert "X-Service-Tenant-ID" not in headers
         assert "X-User-ID" not in headers
 
     @pytest.mark.asyncio
-    async def test_issue_token_uses_legacy_alias_when_jwt_not_configured(
+    async def test_issue_token_uses_admin_key_only_before_platform_tenant_is_bound(
         self,
         identity_client: IdentityServiceClient,
-        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Client should retain legacy headers when outbound JWT cannot be built."""
-        monkeypatch.delenv("SOORMA_AUTH_JWT_SECRET", raising=False)
-        monkeypatch.delenv("SOORMA_IDENTITY_CALLER_JWT", raising=False)
+        """Client should use only the admin key before onboarding returns platform tenant."""
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -113,41 +106,39 @@ class TestIdentityServiceClientContracts:
         )
 
         headers = identity_client._client.post.call_args.kwargs["headers"]
-        assert headers["X-Service-Tenant-ID"] == "svc-tenant"
-        assert headers["X-User-ID"] == "svc-user"
+        assert headers["X-Identity-Admin-Key"] == identity_client.admin_api_key
+        assert "X-Tenant-ID" not in headers
         assert "Authorization" not in headers
+        assert "X-Service-Tenant-ID" not in headers
+        assert "X-User-ID" not in headers
 
     @pytest.mark.asyncio
-    async def test_issue_token_supports_matching_alias_compatibility_mode(
+    async def test_onboard_tenant_does_not_require_bound_platform_tenant(
         self,
         identity_client: IdentityServiceClient,
-        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Compatibility mode should include alias headers alongside JWT auth."""
-        monkeypatch.setenv("SOORMA_AUTH_JWT_SECRET", "test-secret")
-        monkeypatch.setenv("SOORMA_IDENTITY_INCLUDE_LEGACY_ALIAS", "true")
-
+        """Onboarding should work before any platform tenant ID has been bound."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "token": "signed.jwt.value",
-            "token_type": "Bearer",
+            "tenant_domain_id": "tenant-domain-1",
+            "platform_tenant_id": "platform-tenant-1",
+            "bootstrap_admin_principal_id": "principal-1",
+            "status": "created",
         }
         mock_response.raise_for_status = MagicMock()
 
         identity_client._client = AsyncMock()
         identity_client._client.post = AsyncMock(return_value=mock_response)
 
-        await identity_client.issue_token(
-            payload=TokenIssueRequest(
-                principal_id="principal-1",
-                issuance_type=TokenIssuanceType.PLATFORM,
-            ),
+        await identity_client.onboard_tenant(
+            payload=OnboardingRequest(),
             service_tenant_id="svc-tenant",
             service_user_id="svc-user",
         )
 
         headers = identity_client._client.post.call_args.kwargs["headers"]
-        assert headers["Authorization"].startswith("Bearer ")
-        assert headers["X-Service-Tenant-ID"] == "svc-tenant"
-        assert headers["X-User-ID"] == "svc-user"
+        assert headers["X-Identity-Admin-Key"] == identity_client.admin_api_key
+        assert "X-Tenant-ID" not in headers
+        assert "X-Service-Tenant-ID" not in headers
+        assert "X-User-ID" not in headers

--- a/sdk/python/tests/test_memory_client.py
+++ b/sdk/python/tests/test_memory_client.py
@@ -59,12 +59,11 @@ async def test_store_knowledge(memory_client):
     assert result.metadata == {"source": "test"}
     memory_client._client.post.assert_called_once()
     call_headers = memory_client._client.post.call_args.kwargs["headers"]
-    assert call_headers["X-Tenant-ID"] == "platform-tenant-1"
-    assert call_headers["X-Service-Tenant-ID"] == "tenant-1"
-    assert call_headers["X-User-ID"] == "user-1"
+    assert call_headers == {}
 
 
-def test_build_identity_headers_includes_authorization_when_auth_token_present():
+@pytest.mark.asyncio
+async def test_build_identity_headers_includes_authorization_when_auth_token_present():
     """Client should use bearer auth as the active path when auth token is injected."""
     memory_client = MemoryServiceClient(
         base_url="http://localhost:8083",
@@ -72,7 +71,7 @@ def test_build_identity_headers_includes_authorization_when_auth_token_present()
         auth_token="jwt-token-value",
     )
 
-    headers = memory_client._build_identity_headers("tenant-1", "user-1")
+    headers = await memory_client._build_identity_headers("tenant-1", "user-1")
 
     assert headers["Authorization"] == "Bearer jwt-token-value"
     assert "X-Tenant-ID" not in headers
@@ -447,9 +446,7 @@ async def test_create_plan(memory_client):
     
     # Verify headers were sent
     call_args = memory_client._client.post.call_args
-    assert call_args.kwargs["headers"]["X-Tenant-ID"] == "platform-tenant-1"
-    assert call_args.kwargs["headers"]["X-Service-Tenant-ID"] == "tenant-1"
-    assert call_args.kwargs["headers"]["X-User-ID"] == "user-1"
+    assert call_args.kwargs["headers"] == {}
     memory_client._client.post.assert_called_once()
 
 
@@ -491,9 +488,7 @@ async def test_delete_plan(memory_client):
     # Check second call was to delete plan
     second_call = memory_client._client.delete.call_args_list[1]
     assert "/plans/plan-123" in str(second_call)
-    assert second_call.kwargs["headers"]["X-Tenant-ID"] == "platform-tenant-1"
-    assert second_call.kwargs["headers"]["X-Service-Tenant-ID"] == "tenant-1"
-    assert second_call.kwargs["headers"]["X-User-ID"] == "user-1"
+    assert second_call.kwargs["headers"] == {}
 
 
 @pytest.mark.asyncio
@@ -572,9 +567,7 @@ async def test_list_plans_requires_identity(memory_client):
     
     # Verify headers were sent
     call_args = memory_client._client.get.call_args
-    assert call_args.kwargs["headers"]["X-Tenant-ID"] == "platform-tenant-1"
-    assert call_args.kwargs["headers"]["X-Service-Tenant-ID"] == "tenant-1"
-    assert call_args.kwargs["headers"]["X-User-ID"] == "user-1"
+    assert call_args.kwargs["headers"] == {}
     assert call_args.kwargs["params"]["status"] == "running"
     assert call_args.kwargs["params"]["limit"] == 10
     memory_client._client.get.assert_called_once()
@@ -604,9 +597,7 @@ async def test_list_plans(memory_client):
     # Verify service identity headers were sent
     call_args = memory_client._client.get.call_args
     headers = call_args.kwargs["headers"]
-    assert headers["X-Tenant-ID"] == "platform-tenant-1"
-    assert headers["X-Service-Tenant-ID"] == "tenant-1"
-    assert headers["X-User-ID"] == "user-1"
+    assert headers == {}
     memory_client._client.get.assert_called_once()
 
 

--- a/sdk/python/tests/test_memory_client.py
+++ b/sdk/python/tests/test_memory_client.py
@@ -65,7 +65,7 @@ async def test_store_knowledge(memory_client):
 
 
 def test_build_identity_headers_includes_authorization_when_auth_token_present():
-    """Client should include Authorization header when auth token is injected."""
+    """Client should use bearer auth as the active path when auth token is injected."""
     memory_client = MemoryServiceClient(
         base_url="http://localhost:8083",
         platform_tenant_id="platform-tenant-1",
@@ -75,9 +75,9 @@ def test_build_identity_headers_includes_authorization_when_auth_token_present()
     headers = memory_client._build_identity_headers("tenant-1", "user-1")
 
     assert headers["Authorization"] == "Bearer jwt-token-value"
-    assert headers["X-Tenant-ID"] == "platform-tenant-1"
-    assert headers["X-Service-Tenant-ID"] == "tenant-1"
-    assert headers["X-User-ID"] == "user-1"
+    assert "X-Tenant-ID" not in headers
+    assert "X-Service-Tenant-ID" not in headers
+    assert "X-User-ID" not in headers
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_memory_client_deletion.py
+++ b/sdk/python/tests/test_memory_client_deletion.py
@@ -187,11 +187,10 @@ class TestMemoryClientWorkingMemoryDeletion:
             call_args = async_mock.call_args
             assert test_ids["plan_id"] in call_args[0][0]
             assert test_ids["key"] in call_args[0][0]
-            # Check headers include tenant_id and user_id
+            # Bearer auth is the active path. Without a token, the SDK should
+            # not project legacy identity headers.
             headers = call_args[1]["headers"]
-            assert headers["X-Tenant-ID"]
-            assert headers["X-Service-Tenant-ID"] == test_ids["tenant_id"]
-            assert headers["X-User-ID"] == test_ids["user_id"]
+            assert headers == {}
 
 
 class TestWorkflowStateDelete:

--- a/sdk/python/tests/test_registry_service_client.py
+++ b/sdk/python/tests/test_registry_service_client.py
@@ -80,15 +80,10 @@ async def test_registry_client_includes_bearer_auth_when_configured():
 
 
 @pytest.mark.asyncio
-async def test_registry_client_falls_back_to_developer_tenant_header():
-    """RegistryClient should use the developer tenant header when bearer auth is absent."""
-    client = RegistryClient(
-        base_url="http://test-registry",
-        auth_token="",
-        developer_tenant_id="00000000-0000-0000-0000-000000000123",
-    )
+async def test_registry_client_omits_auth_headers_when_unconfigured():
+    """RegistryClient should not infer auth from environment or header fallbacks."""
+    client = RegistryClient(base_url="http://test-registry")
 
     headers = await client._build_auth_headers()
 
-    assert headers["X-Tenant-ID"] == "00000000-0000-0000-0000-000000000123"
-    assert "Authorization" not in headers
+    assert headers == {}

--- a/sdk/python/tests/test_registry_service_client.py
+++ b/sdk/python/tests/test_registry_service_client.py
@@ -77,3 +77,18 @@ async def test_registry_client_includes_bearer_auth_when_configured():
 
     assert headers["Authorization"] == "Bearer jwt-token"
     assert "X-Tenant-ID" not in headers
+
+
+@pytest.mark.asyncio
+async def test_registry_client_falls_back_to_developer_tenant_header():
+    """RegistryClient should use the developer tenant header when bearer auth is absent."""
+    client = RegistryClient(
+        base_url="http://test-registry",
+        auth_token="",
+        developer_tenant_id="00000000-0000-0000-0000-000000000123",
+    )
+
+    headers = await client._build_auth_headers()
+
+    assert headers["X-Tenant-ID"] == "00000000-0000-0000-0000-000000000123"
+    assert "Authorization" not in headers

--- a/sdk/python/tests/test_registry_service_client.py
+++ b/sdk/python/tests/test_registry_service_client.py
@@ -66,3 +66,14 @@ async def test_register_event_structured():
     assert event_payload["topic"] == "action-requests"
     assert event_payload["payloadSchema"]["type"] == "object"
     assert event_payload["responseSchema"]["type"] == "object"
+
+
+@pytest.mark.asyncio
+async def test_registry_client_includes_bearer_auth_when_configured():
+    """RegistryClient should include Authorization header when auth_token is set."""
+    client = RegistryClient(base_url="http://test-registry", auth_token="jwt-token")
+
+    headers = await client._build_auth_headers()
+
+    assert headers["Authorization"] == "Bearer jwt-token"
+    assert "X-Tenant-ID" not in headers

--- a/sdk/python/tests/test_sdk_semantic_upsert_privacy.py
+++ b/sdk/python/tests/test_sdk_semantic_upsert_privacy.py
@@ -61,11 +61,9 @@ class TestSemanticUpsertSDK:
         assert result.user_id == "user-alice"
         assert result.is_public == False
         
-        # Verify API call includes identity headers
+        # Verify the SDK does not emit legacy identity headers without bearer auth
         call_kwargs = memory_client._client.post.call_args.kwargs
-        assert call_kwargs["headers"]["X-Tenant-ID"] == "platform-tenant-1"
-        assert call_kwargs["headers"]["X-Service-Tenant-ID"] == "tenant-1"
-        assert call_kwargs["headers"]["X-User-ID"] == "user-alice"
+        assert call_kwargs["headers"] == {}
         
         # Verify DTO doesn't include user_id in body
         dto_payload = call_kwargs["json"]
@@ -223,10 +221,9 @@ class TestSemanticQuerySDK:
         assert results[0].content == "Search result"
         assert results[0].user_id == "user-alice"
         
-        # Verify service identity passed via headers
+        # Verify the SDK does not emit legacy service identity headers
         call_kwargs = memory_client._client.post.call_args.kwargs
-        assert call_kwargs["headers"]["X-Service-Tenant-ID"] == "tenant-1"
-        assert call_kwargs["headers"]["X-User-ID"] == "user-alice"
+        assert call_kwargs["headers"] == {}
         
         # Verify all params passed as query parameters (not JSON body)
         params = call_kwargs["params"]

--- a/sdk/python/tests/test_tracker_service_client.py
+++ b/sdk/python/tests/test_tracker_service_client.py
@@ -30,7 +30,7 @@ def tracker_client():
 
 
 def test_build_identity_headers_includes_authorization_when_auth_token_present():
-    """Tracker client should forward injected auth token as bearer header."""
+    """Tracker client should use bearer auth as the active path when auth token is injected."""
     tracker_client = TrackerServiceClient(
         base_url="http://localhost:8084",
         platform_tenant_id="platform-tenant-1",
@@ -40,9 +40,9 @@ def test_build_identity_headers_includes_authorization_when_auth_token_present()
     headers = tracker_client._build_identity_headers("tenant-123", "user-456")
 
     assert headers["Authorization"] == "Bearer jwt-token-value"
-    assert headers["X-Tenant-ID"] == "platform-tenant-1"
-    assert headers["X-Service-Tenant-ID"] == "tenant-123"
-    assert headers["X-User-ID"] == "user-456"
+    assert "X-Tenant-ID" not in headers
+    assert "X-Service-Tenant-ID" not in headers
+    assert "X-User-ID" not in headers
 
 
 @pytest.fixture

--- a/sdk/python/tests/test_tracker_service_client.py
+++ b/sdk/python/tests/test_tracker_service_client.py
@@ -29,7 +29,8 @@ def tracker_client():
     )
 
 
-def test_build_identity_headers_includes_authorization_when_auth_token_present():
+@pytest.mark.asyncio
+async def test_build_identity_headers_includes_authorization_when_auth_token_present():
     """Tracker client should use bearer auth as the active path when auth token is injected."""
     tracker_client = TrackerServiceClient(
         base_url="http://localhost:8084",
@@ -37,7 +38,7 @@ def test_build_identity_headers_includes_authorization_when_auth_token_present()
         auth_token="jwt-token-value",
     )
 
-    headers = tracker_client._build_identity_headers("tenant-123", "user-456")
+    headers = await tracker_client._build_identity_headers("tenant-123", "user-456")
 
     assert headers["Authorization"] == "Bearer jwt-token-value"
     assert "X-Tenant-ID" not in headers
@@ -93,9 +94,7 @@ class TestGetPlanProgress:
         # Verify headers were sent
         tracker_client._client.get.assert_called_once()
         call_args = tracker_client._client.get.call_args
-        assert call_args.kwargs["headers"]["X-Tenant-ID"] == "platform-tenant-1"
-        assert call_args.kwargs["headers"]["X-Service-Tenant-ID"] == mock_auth["tenant_id"]
-        assert call_args.kwargs["headers"]["X-User-ID"] == mock_auth["user_id"]
+        assert call_args.kwargs["headers"] == {}
     
     @pytest.mark.asyncio
     async def test_get_plan_progress_not_found(self, tracker_client, mock_auth):

--- a/services/event-service/src/api/dependencies.py
+++ b/services/event-service/src/api/dependencies.py
@@ -1,12 +1,13 @@
 """
 API dependencies for authentication and request context.
 
-Event Service Authentication Model (v0.7.x):
-  platform_tenant_id is extracted from the X-Tenant-ID header by TenancyMiddleware
-  and stored on request.state. get_platform_tenant_id reads it as a plain str.
+Event Service Authentication Model (v0.8.x):
+  platform_tenant_id is extracted from validated bearer-token identity by
+  TenancyMiddleware and stored on request.state. get_platform_tenant_id reads it
+  as a plain str.
 
-  v0.8.0+: this extraction path can shift to API key / JWT without changing
-  route business logic.
+  Event Service remains the trust boundary for platform-tenant enrichment; SDK
+  callers must not inject platform_tenant_id into outbound event payloads.
 """
 
 from soorma_service_common import get_platform_tenant_id  # noqa: F401

--- a/services/event-service/tests/conftest.py
+++ b/services/event-service/tests/conftest.py
@@ -3,10 +3,14 @@ Pytest configuration for Event Service tests.
 """
 import pytest
 import os
+from datetime import datetime, timedelta, timezone
+
+import jwt
 
 # Set test environment variables
 os.environ["EVENT_ADAPTER"] = "memory"
 os.environ["DEBUG"] = "true"
+os.environ.setdefault("SOORMA_AUTH_JWT_SECRET", "dev-identity-signing-key")
 
 
 @pytest.fixture(scope="session")
@@ -18,5 +22,47 @@ def event_loop_policy():
 
 @pytest.fixture
 def tenancy_headers():
-    """Default authenticated platform tenant header used for publish tests."""
-    return {"X-Tenant-ID": "spt_test"}
+    """Default authenticated headers used for protected event-service routes."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "sub": "event-test-user",
+            "platform_tenant_id": "spt_test",
+            "service_tenant_id": "st_test-tenant",
+            "service_user_id": "su_test-user",
+            "principal_id": "event-test-user",
+            "principal_type": "service",
+            "roles": ["service"],
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        },
+        os.environ["SOORMA_AUTH_JWT_SECRET"],
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def build_auth_headers(
+    platform_tenant_id: str = "spt_test",
+    service_tenant_id: str = "st_test-tenant",
+    service_user_id: str = "su_test-user",
+    principal_id: str = "event-test-user",
+) -> dict[str, str]:
+    """Build JWT bearer headers for event-service tests."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "sub": principal_id,
+            "platform_tenant_id": platform_tenant_id,
+            "service_tenant_id": service_tenant_id,
+            "service_user_id": service_user_id,
+            "principal_id": principal_id,
+            "principal_type": "service",
+            "roles": ["service"],
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        },
+        os.environ["SOORMA_AUTH_JWT_SECRET"],
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}

--- a/services/event-service/tests/test_api.py
+++ b/services/event-service/tests/test_api.py
@@ -13,19 +13,20 @@ os.environ["DEBUG"] = "true"
 
 from src.main import app
 from src.services.event_manager import event_manager
+from .conftest import build_auth_headers
 
 
 @pytest.fixture
-def client():
+def client(tenancy_headers):
     """Create a test client."""
-    return TestClient(app)
+    return TestClient(app, headers=tenancy_headers)
 
 
 @pytest.fixture
-async def async_client():
+async def async_client(tenancy_headers):
     """Create an async test client with lifespan."""
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    async with AsyncClient(transport=transport, base_url="http://test", headers=tenancy_headers) as ac:
         # Ensure adapter is connected for tests
         # Note: lifespan manager in main.py calls event_manager.initialize()
         # which connects the adapter. But AsyncClient with lifespan should handle it.
@@ -84,7 +85,6 @@ class TestPublishEndpoint:
         response = await async_client.post(
             "/v1/events/publish",
             json=event,
-            headers={"X-Tenant-ID": "spt_test"},
         )
         
         # May be 503 if adapter not connected (acceptable in unit test)
@@ -128,7 +128,6 @@ class TestPublishEndpoint:
         response = await async_client.post(
             "/v1/events/publish",
             json=event,
-            headers={"X-Tenant-ID": "spt_test"},
         )
         
         # May be 503 if adapter not connected (acceptable in unit test)

--- a/services/event-service/tests/test_hello_world_flow.py
+++ b/services/event-service/tests/test_hello_world_flow.py
@@ -7,15 +7,16 @@ from httpx import AsyncClient, ASGITransport
 
 from src.main import app
 from src.services.event_manager import event_manager
+from .conftest import build_auth_headers
 
 # We need to import EventClient from the SDK
 # Since SDK is in core/sdk/python, we might need to adjust python path or install it
 # For this test, I'll mock the EventClient's network calls to hit our app directly
 
 @pytest.fixture
-async def async_client():
+async def async_client(tenancy_headers):
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    async with AsyncClient(transport=transport, base_url="http://test", headers=tenancy_headers) as ac:
         if not event_manager.adapter or not event_manager.adapter.is_connected:
              await event_manager.initialize()
         yield ac

--- a/services/event-service/tests/test_multi_tenancy.py
+++ b/services/event-service/tests/test_multi_tenancy.py
@@ -7,6 +7,7 @@ from httpx import ASGITransport, AsyncClient
 
 from soorma_common.tenancy import DEFAULT_PLATFORM_TENANT_ID
 from src.main import app
+from .conftest import build_auth_headers
 
 
 @pytest.fixture
@@ -41,7 +42,7 @@ async def test_publish_overwrites_payload_platform_tenant_id(async_client):
         response = await async_client.post(
             "/v1/events/publish",
             json=payload,
-            headers={"X-Tenant-ID": "spt_real"},
+            headers=build_auth_headers(platform_tenant_id="spt_real"),
         )
 
     assert response.status_code == 200
@@ -50,12 +51,16 @@ async def test_publish_overwrites_payload_platform_tenant_id(async_client):
 
 
 @pytest.mark.asyncio
-async def test_publish_fallback_to_default_platform_tenant(async_client):
-    """Missing X-Tenant-ID should use DEFAULT_PLATFORM_TENANT_ID fallback."""
+async def test_publish_uses_default_platform_tenant_from_jwt(async_client):
+    """JWT platform tenant claims may use DEFAULT_PLATFORM_TENANT_ID explicitly."""
     payload = _base_event_payload()
 
     with patch("src.api.routes.events.event_manager.publish", new=AsyncMock()) as mock_publish:
-        response = await async_client.post("/v1/events/publish", json=payload)
+        response = await async_client.post(
+            "/v1/events/publish",
+            json=payload,
+            headers=build_auth_headers(platform_tenant_id=DEFAULT_PLATFORM_TENANT_ID),
+        )
 
     assert response.status_code == 200
     publish_message = mock_publish.await_args.args[1]
@@ -100,15 +105,14 @@ async def test_publish_rejects_missing_user_id_after_sanitization(async_client, 
 
 @pytest.mark.asyncio
 async def test_publish_rejects_oversized_platform_tenant_id(async_client):
-    """Oversized platform_tenant_id values must fail closed."""
+    """Oversized platform_tenant_id claims must fail closed."""
     payload = _base_event_payload()
 
-    oversized_header = {"X-Tenant-ID": "a" * 65}
     with patch("src.api.routes.events.event_manager.publish", new=AsyncMock()) as mock_publish:
         response = await async_client.post(
             "/v1/events/publish",
             json=payload,
-            headers=oversized_header,
+            headers=build_auth_headers(platform_tenant_id="a" * 65),
         )
 
     assert response.status_code == 422

--- a/services/event-service/tests/test_sse_integration.py
+++ b/services/event-service/tests/test_sse_integration.py
@@ -5,6 +5,7 @@ import uvicorn
 from httpx import AsyncClient
 from src.main import app
 from src.services.event_manager import event_manager
+from .conftest import build_auth_headers
 
 @pytest.fixture
 async def server():
@@ -39,7 +40,11 @@ async def test_sse_stream_integration(server):
 
     # Start the stream request
     async with AsyncClient(base_url="http://127.0.0.1:8001") as client:
-        async with client.stream("GET", f"/v1/events/stream?topics={topics}&agent_id={agent_id}") as response:
+        async with client.stream(
+            "GET",
+            f"/v1/events/stream?topics={topics}&agent_id={agent_id}",
+            headers=build_auth_headers(),
+        ) as response:
             assert response.status_code == 200
             
             lines = response.aiter_lines()

--- a/services/identity-service/CHANGELOG.md
+++ b/services/identity-service/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added canonical `tenant_id` claim issuance alongside compatibility claims for cutover consumers.
+- Documented RS256/JWKS-first local bootstrap defaults and fail-closed verifier expectations for `soorma dev`.
 - Added initial identity-service scaffold for AI-DLC code generation.
 - Expanded service README with API, auth, token-contract, and testing guidance.
 - Added technical docs in `docs/identity_service/` for architecture and use cases.

--- a/services/identity-service/README.md
+++ b/services/identity-service/README.md
@@ -84,23 +84,30 @@ Delegated issuance failures use typed safe API errors:
 | `SYNC_DATABASE_URL` | No | derived from `DATABASE_URL` | Sync connection used by Alembic/migrations when provided. |
 | `IS_PROD` | No | `false` | Disables docs endpoints when set to `true`. |
 | `IDENTITY_ADMIN_API_KEY` | Yes (for protected admin routes) | `dev-identity-admin` | Header key checked by admin authorization dependency (`X-Identity-Admin-Key`). |
-| `IDENTITY_SIGNING_KEY` | Yes for deterministic token signing | `dev-identity-signing-key` | Signing key used by local provider facade for issuing JWTs. |
-| `SOORMA_AUTH_JWT_SECRET` | Required for bearer JWT validation path | `dev-identity-signing-key` | Secret used by tenancy middleware when validating incoming bearer JWTs. |
+| `IDENTITY_SIGNING_ALGORITHM` | No | `RS256` when `soorma dev` bootstraps the stack | Explicit signing mode for provider facade. |
+| `IDENTITY_ACTIVE_SIGNING_KID` | No | `dev-rs256` | Active RSA signing key ID published in issued token headers. |
+| `IDENTITY_SIGNING_PRIVATE_KEYRING_JSON` | Required for RS256 issuance | derived from persisted `.soorma/identity/identity-signing-private.pem` | JSON keyring used by provider facade for signing. |
+| `IDENTITY_SIGNING_PUBLIC_KEYRING_JSON` | Required for RS256 JWKS publication | derived from persisted `.soorma/identity/identity-signing-public.pem` | JSON keyring used for JWKS publication and static verifier fallback. |
+| `IDENTITY_JWKS_PUBLICATION_JSON` | No | derived from persisted `.soorma/identity/identity-jwks.json` | Published JWKS payload for discovery and verifier alignment. |
+| `SOORMA_AUTH_JWKS_JSON` | Required for inline bearer JWT validation path | derived from persisted `.soorma/identity/identity-jwks.json` | JWKS used by tenancy middleware when validating incoming bearer JWTs. |
+| `SOORMA_AUTH_JWT_PUBLIC_KEYS_JSON` | No | derived from persisted `.soorma/identity/identity-signing-public.pem` | Static RS256 verifier fallback for fail-closed validation. |
 | `SOORMA_AUTH_JWT_ISSUER` | No | `soorma-identity-service` | Optional issuer validation for incoming bearer JWTs. |
 | `SOORMA_AUTH_JWT_AUDIENCE` | No | `soorma-services` | Optional audience validation for incoming bearer JWTs. |
 
 Notes:
-- If a bearer JWT is sent but `SOORMA_AUTH_JWT_SECRET` is not configured, request validation fails closed with `401`.
-- During coexistence mode, legacy headers are used only when bearer JWT is absent.
+- If a bearer JWT is sent but JWKS/public-key verifier material is missing or invalid, request validation fails closed with `401`.
+- Public discovery routes stay bypassed, but secured non-public routes no longer fall back to legacy tenant headers when bearer JWT is absent.
 
 ## soorma dev Local Startup Behavior
 
-`soorma dev --start` generates a local compose stack and injects identity/JWT env vars with local defaults.
+`soorma dev --start` generates a local compose stack, creates RSA signing material under `.soorma/identity/` on first run, and injects RS256 signing keyrings plus inline JWKS/public-key verifier material derived from those persisted files.
 
 - Compose file: `.soorma/docker-compose.yml`
 - Generated env file: `.soorma/.env`
+- Persisted identity files: `.soorma/identity/identity-signing-private.pem`, `.soorma/identity/identity-signing-public.pem`, `.soorma/identity/identity-jwks.json`
 
 To override defaults, export variables before running `soorma dev --start`.
+To rotate the local dev keypair, delete the files under `.soorma/identity/` and run `soorma dev` again.
 
 ## Local Run
 

--- a/services/identity-service/src/identity_service/services/token_service.py
+++ b/services/identity-service/src/identity_service/services/token_service.py
@@ -76,6 +76,7 @@ class TokenService:
             "sub": request.principal_id,
             "aud": "soorma-services",
             "jti": str(uuid4()),
+            "tenant_id": str(tenant_domain["platform_tenant_id"]),
             "platform_tenant_id": str(tenant_domain["platform_tenant_id"]),
             "principal_id": request.principal_id,
             "principal_type": str(principal["principal_type"]),

--- a/services/identity-service/tests/test_token_api.py
+++ b/services/identity-service/tests/test_token_api.py
@@ -49,6 +49,7 @@ async def test_platform_token_issuance_returns_bearer_token(db_session):
     assert claims["iss"] == "soorma-identity-service"
     assert claims["sub"] == onboarding.bootstrap_admin_principal_id
     assert claims["aud"] == "soorma-services"
+    assert claims["tenant_id"] == onboarding.platform_tenant_id
     assert claims["platform_tenant_id"] == onboarding.platform_tenant_id
     assert claims["principal_id"] == onboarding.bootstrap_admin_principal_id
     assert claims["principal_type"] == "admin"

--- a/services/memory/tests/conftest.py
+++ b/services/memory/tests/conftest.py
@@ -2,7 +2,10 @@
 
 import pytest
 import asyncio
+from datetime import datetime, timedelta, timezone
 from typing import AsyncGenerator
+
+import jwt
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
 from memory_service.core.database import Base
@@ -64,4 +67,31 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
     monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("SOORMA_AUTH_JWT_SECRET", "dev-identity-signing-key")
+
+
+def build_auth_headers(
+    platform_tenant_id: str = TEST_PLATFORM_TENANT_ID,
+    service_tenant_id: str = TEST_SERVICE_TENANT_ID,
+    service_user_id: str = TEST_SERVICE_USER_ID,
+    principal_id: str = TEST_SERVICE_USER_ID,
+) -> dict[str, str]:
+    """Build JWT bearer headers for memory-service tests."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "sub": principal_id,
+            "platform_tenant_id": platform_tenant_id,
+            "service_tenant_id": service_tenant_id,
+            "service_user_id": service_user_id,
+            "principal_id": principal_id,
+            "principal_type": "service",
+            "roles": ["service"],
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        },
+        "dev-identity-signing-key",
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
 

--- a/services/memory/tests/test_api_validation.py
+++ b/services/memory/tests/test_api_validation.py
@@ -10,12 +10,13 @@ from memory_service.core.config import settings
 from memory_service.core.database import get_db
 from memory_service.core.dependencies import TenantContext, get_tenant_context
 from memory_service.services.data_deletion import MemoryDataDeletion
+from .conftest import build_auth_headers
 
 
 @pytest.fixture
 def client():
     """Create test client."""
-    return TestClient(app)
+    return TestClient(app, headers=build_auth_headers())
 
 
 class TestHealthEndpoint:
@@ -84,7 +85,10 @@ class TestIdentityAndAdminGuards:
             try:
                 response = client.delete(
                     "/v1/memory/admin/platform/spt_test-00000",
-                    headers={"X-Memory-Admin-Key": settings.memory_admin_api_key},
+                    headers={
+                        **build_auth_headers(),
+                        "X-Memory-Admin-Key": settings.memory_admin_api_key,
+                    },
                 )
                 assert response.status_code == 204
             finally:

--- a/services/registry/src/registry_service/api/dependencies.py
+++ b/services/registry/src/registry_service/api/dependencies.py
@@ -1,16 +1,18 @@
 """
 API dependencies for authentication and request context.
 
-Registry Service Authentication Model (v0.7.x):
-  platform_tenant_id is extracted from the X-Tenant-ID header by TenancyMiddleware
-  and stored on request.state. get_platform_tenant_id reads it as a plain str.
+Registry Service Authentication Model (v0.8.x):
+  platform_tenant_id is extracted from validated bearer-token identity by
+  TenancyMiddleware and stored on request.state. get_platform_tenant_id reads it
+  as a plain str.
 
   get_tenanted_db wraps the service's own get_db session factory:
     - Reads identity from request.state
     - Calls PostgreSQL set_config x3 to activate RLS for the session
     - Yields the AsyncSession
 
-  v0.8.0+: will be replaced with API Key / machine token validation.
+  Future hardening may add selected API-key control-plane flows, but bearer-
+  authenticated machine and developer principals are the current runtime model.
 """
 from soorma_service_common import (  # noqa: F401
   RouteAuthPolicy,

--- a/services/registry/tests/conftest.py
+++ b/services/registry/tests/conftest.py
@@ -4,6 +4,9 @@ Test configuration and fixtures.
 import pytest
 import os
 import asyncio
+from datetime import datetime, timedelta, timezone
+
+import jwt
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from fastapi.testclient import TestClient
 
@@ -17,6 +20,7 @@ TEST_DATABASE_URL = f"sqlite+aiosqlite:///./{TEST_DB_FILE}"
 # Set the environment variable BEFORE importing the app
 # This ensures the app uses the test database from the start
 os.environ["DATABASE_URL"] = TEST_DATABASE_URL
+os.environ.setdefault("SOORMA_AUTH_JWT_SECRET", "dev-identity-signing-key")
 
 # Now import after setting environment variables
 from registry_service.main import app
@@ -73,9 +77,34 @@ def setup_test_db():
 @pytest.fixture
 def client():
     """
-    Create a test client with sentinel X-Tenant-ID header.
-    All API calls automatically include the developer tenant header.
+    Create a test client with authenticated bearer headers.
     """
-    with TestClient(app, headers={"X-Tenant-ID": TEST_TENANT_ID}) as test_client:
+    with TestClient(app, headers=build_auth_headers(TEST_TENANT_ID)) as test_client:
         yield test_client
+
+
+def build_auth_headers(
+    platform_tenant_id: str = TEST_TENANT_ID,
+    service_tenant_id: str = "st_test-tenant",
+    service_user_id: str = "su_test-user",
+    principal_id: str = "registry-test-user",
+) -> dict[str, str]:
+    """Build JWT bearer headers for registry-service tests."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "sub": principal_id,
+            "platform_tenant_id": platform_tenant_id,
+            "service_tenant_id": service_tenant_id,
+            "service_user_id": service_user_id,
+            "principal_id": principal_id,
+            "principal_type": "service",
+            "roles": ["service"],
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        },
+        os.environ["SOORMA_AUTH_JWT_SECRET"],
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
 

--- a/services/registry/tests/test_agent_discovery.py
+++ b/services/registry/tests/test_agent_discovery.py
@@ -8,6 +8,11 @@ Expected failures: 500 Internal Server Error (server-side NotImplementedError)
 NOT ImportError / AttributeError — those would mean stubs were not created.
 """
 import pytest
+from fastapi.testclient import TestClient
+
+from registry_service.main import app
+
+from .conftest import build_auth_headers
 
 TEST_TENANT_ID = "spt_00000000-0000-0000-0000-000000000000"
 
@@ -122,12 +127,10 @@ class TestDiscoverAgents:
         assert "all-worker-003" in agent_ids
 
     def test_discover_agents_requires_tenant_header(self):
-        """GET /v1/agents/discover without X-Tenant-ID defaults to DEFAULT_PLATFORM_TENANT_ID (200)."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
+        """GET /v1/agents/discover without bearer auth returns 401."""
         no_auth_client = TestClient(app)
         response = no_auth_client.get("/v1/agents/discover")
-        assert response.status_code == 200
+        assert response.status_code == 401
 
     def test_discover_agents_multiple_consumers(self, client):
         """Multiple agents consuming the same event are all returned."""
@@ -141,13 +144,10 @@ class TestDiscoverAgents:
 
     def test_discover_agents_cross_tenant_isolation(self):
         """Agent registered by Tenant A is not discoverable by Tenant B."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
-
         tenant_a = "spt_11111111-1111-1111-1111-111111111111"
         tenant_b = "spt_22222222-2222-2222-2222-222222222222"
-        client_a = TestClient(app, headers={"X-Tenant-ID": tenant_a})
-        client_b = TestClient(app, headers={"X-Tenant-ID": tenant_b})
+        client_a = TestClient(app, headers=build_auth_headers(tenant_a))
+        client_b = TestClient(app, headers=build_auth_headers(tenant_b))
 
         # Register agent as Tenant A
         r = client_a.post(

--- a/services/registry/tests/test_schema_endpoints.py
+++ b/services/registry/tests/test_schema_endpoints.py
@@ -8,6 +8,11 @@ Expected failures: 500 Internal Server Error (server-side NotImplementedError)
 NOT ImportError or AttributeError — those would mean stubs were not created.
 """
 import pytest
+from fastapi.testclient import TestClient
+
+from registry_service.main import app
+
+from .conftest import build_auth_headers
 
 # Re-use conftest.py fixtures: client (TEST_TENANT_ID) and setup_test_db
 TEST_TENANT_ID = "spt_00000000-0000-0000-0000-000000000000"
@@ -73,12 +78,10 @@ class TestRegisterSchema:
         assert response.status_code == 200
 
     def test_register_schema_requires_tenant_header(self):
-        """POST /v1/schemas without X-Tenant-ID defaults to DEFAULT_PLATFORM_TENANT_ID (200)."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
+        """POST /v1/schemas without bearer auth returns 401."""
         no_auth_client = TestClient(app)
         response = no_auth_client.post("/v1/schemas", json=_schema_payload())
-        assert response.status_code == 200
+        assert response.status_code == 401
 
     def test_register_schema_with_owner_agent_id(self, client):
         """Schema can be registered with an owner_agent_id."""
@@ -128,13 +131,10 @@ class TestGetSchema:
         assert response.json()["version"] == "2.0.0"
 
     def test_get_schema_requires_tenant_header(self):
-        """GET /v1/schemas/{name} without X-Tenant-ID defaults to DEFAULT_PLATFORM_TENANT_ID.
-        Schema not registered under that tenant, so returns 404."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
+        """GET /v1/schemas/{name} without bearer auth returns 401."""
         no_auth_client = TestClient(app)
         response = no_auth_client.get("/v1/schemas/any_schema")
-        assert response.status_code == 404
+        assert response.status_code == 401
 
 
 # ─── GET /v1/schemas/{schema_name}/versions/{version} ─────────────────────────
@@ -198,12 +198,10 @@ class TestListSchemas:
         assert data["schemas"] == []
 
     def test_list_schemas_requires_tenant_header(self):
-        """GET /v1/schemas without X-Tenant-ID defaults to DEFAULT_PLATFORM_TENANT_ID (200)."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
+        """GET /v1/schemas without bearer auth returns 401."""
         no_auth_client = TestClient(app)
         response = no_auth_client.get("/v1/schemas")
-        assert response.status_code == 200
+        assert response.status_code == 401
 
 
 # ─── Cross-tenant isolation ────────────────────────────────────────────────────
@@ -213,11 +211,8 @@ class TestSchemaCrossTenantIsolation:
 
     def test_schema_cross_tenant_isolation(self):
         """Tenant A schemas are NOT visible to Tenant B."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
-
-        client_a = TestClient(app, headers={"X-Tenant-ID": TENANT_A})
-        client_b = TestClient(app, headers={"X-Tenant-ID": TENANT_B})
+        client_a = TestClient(app, headers=build_auth_headers(TENANT_A))
+        client_b = TestClient(app, headers=build_auth_headers(TENANT_B))
 
         # Register schema as Tenant A
         r = client_a.post("/v1/schemas", json=_schema_payload(schema_name="secret_v1"))
@@ -229,11 +224,8 @@ class TestSchemaCrossTenantIsolation:
 
     def test_same_schema_name_different_tenants(self):
         """Both tenants can register schemas with the same name independently."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
-
-        client_a = TestClient(app, headers={"X-Tenant-ID": TENANT_A})
-        client_b = TestClient(app, headers={"X-Tenant-ID": TENANT_B})
+        client_a = TestClient(app, headers=build_auth_headers(TENANT_A))
+        client_b = TestClient(app, headers=build_auth_headers(TENANT_B))
 
         r_a = client_a.post("/v1/schemas", json=_schema_payload(schema_name="common_name_v1"))
         r_b = client_b.post("/v1/schemas", json=_schema_payload(schema_name="common_name_v1"))
@@ -242,11 +234,8 @@ class TestSchemaCrossTenantIsolation:
 
     def test_list_schemas_tenant_scoped(self):
         """List only returns schemas for the requesting tenant."""
-        from fastapi.testclient import TestClient
-        from registry_service.main import app
-
-        client_a = TestClient(app, headers={"X-Tenant-ID": TENANT_A})
-        client_b = TestClient(app, headers={"X-Tenant-ID": TENANT_B})
+        client_a = TestClient(app, headers=build_auth_headers(TENANT_A))
+        client_b = TestClient(app, headers=build_auth_headers(TENANT_B))
 
         client_a.post("/v1/schemas", json=_schema_payload(schema_name="tenant_a_exclusive_v1"))
         response = client_b.get("/v1/schemas")

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -29,17 +29,21 @@ The Tracker Service provides real-time workflow observability by subscribing to 
 
 All data is isolated by tenant using PostgreSQL Row-Level Security (RLS):
 
-### Required Headers
+### Required Authentication
 
-Every API request **MUST** include authentication headers:
+Every secured API request **MUST** include a bearer token:
 
-- `X-Tenant-ID`: Tenant identifier (UUID format)
-- `X-User-ID`: User identifier (UUID format)
+- `Authorization: Bearer <jwt>`
+
+The validated JWT must carry:
+
+- `platform_tenant_id` or `tenant_id`
+- `service_tenant_id`
+- `service_user_id` or `user_id`
 
 **Example:**
 ```bash
-curl -H "X-Tenant-ID: 550e8400-e29b-41d4-a716-446655440000" \
-     -H "X-User-ID: 660e8400-e29b-41d4-a716-446655440001" \
+curl -H "Authorization: Bearer $SOORMA_TOKEN" \
      http://localhost:8084/v1/tracker/plans/plan-123
 ```
 
@@ -57,7 +61,7 @@ USING (
 ```
 
 **How it works:**
-1. Service extracts `X-Tenant-ID` and `X-User-ID` from request headers
+1. Shared middleware validates the bearer token and projects tenant/user identity into request state
 2. Sets PostgreSQL session variables: `SET app.tenant_id = '...'`
 3. All queries automatically filtered by RLS policies
 4. Users can ONLY see their own data within their tenant
@@ -65,18 +69,17 @@ USING (
 **Tenant Isolation Guarantees:**
 - No cross-tenant data leakage (enforced at database level)
 - No cross-user data visibility within same tenant
-- Failed authentication → 403 Forbidden
-- Missing headers → 403 Forbidden
+- Failed authentication → 401 Unauthorized
+- Missing bearer token → 401 Unauthorized
 
 API requests MUST include:
-- `X-Tenant-ID` header
-- `X-User-ID` header
+- `Authorization: Bearer <jwt>`
 
 ## API Endpoints
 
 ### Query APIs (Read-Only)
 
-All endpoints require `X-Tenant-ID` and `X-User-ID` headers.
+All secured endpoints require `Authorization: Bearer <jwt>`.
 
 #### Get Plan Progress
 
@@ -86,8 +89,7 @@ Returns plan execution summary with task completion counts.
 
 **Example Request:**
 ```bash
-curl -H "X-Tenant-ID: 550e8400-e29b-41d4-a716-446655440000" \
-     -H "X-User-ID: 660e8400-e29b-41d4-a716-446655440001" \
+curl -H "Authorization: Bearer $SOORMA_TOKEN" \
      http://localhost:8084/v1/tracker/plans/plan-abc123
 ```
 
@@ -106,7 +108,7 @@ curl -H "X-Tenant-ID: 550e8400-e29b-41d4-a716-446655440000" \
 ```
 
 **Error Responses:**
-- `403 Forbidden` - Missing or invalid tenant/user headers
+- `401 Unauthorized` - Missing or invalid bearer token
 - `404 Not Found` - Plan does not exist or not accessible to this user
 - `500 Internal Server Error` - Database or service error
 
@@ -118,8 +120,7 @@ Returns execution history for all tasks in the plan.
 
 **Example Request:**
 ```bash
-curl -H "X-Tenant-ID: 550e8400-e29b-41d4-a716-446655440000" \
-     -H "X-User-ID: 660e8400-e29b-41d4-a716-446655440001" \
+curl -H "Authorization: Bearer $SOORMA_TOKEN" \
      http://localhost:8084/v1/tracker/plans/plan-abc123/tasks
 ```
 
@@ -157,8 +158,7 @@ Returns chronological event timeline for distributed trace reconstruction.
 
 **Example Request:**
 ```bash
-curl -H "X-Tenant-ID: 550e8400-e29b-41d4-a716-446655440000" \
-     -H "X-User-ID: 660e8400-e29b-41d4-a716-446655440001" \
+curl -H "Authorization: Bearer $SOORMA_TOKEN" \
      http://localhost:8084/v1/tracker/plans/plan-abc123/timeline
 ```
 
@@ -413,13 +413,12 @@ If you must call the API directly (e.g., from non-Python clients):
 
 ```bash
 # Get plan progress
-curl -H "X-Tenant-ID: 550e8400-e29b-41d4-a716-446655440000" \
-     -H "X-User-ID: 660e8400-e29b-41d4-a716-446655440001" \
+curl -H "Authorization: Bearer $SOORMA_TOKEN" \
      http://localhost:8084/v1/tracker/plans/plan-abc123
 ```
 
 **Important:** You MUST manually manage:
-- Authentication headers on every request
+- Bearer authentication on every secured request
 - Error handling (403, 404, 500)
 - Response parsing and validation
 - Retry logic for transient failures

--- a/services/tracker/tests/conftest.py
+++ b/services/tracker/tests/conftest.py
@@ -1,6 +1,10 @@
 """Pytest configuration and fixtures for tracker service tests."""
 
+import os
 import pytest
+from datetime import datetime, timedelta, timezone
+
+import jwt
 from fastapi import Request
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 
@@ -12,6 +16,43 @@ from tracker_service.main import app
 
 # Test database URL (in-memory SQLite for fast tests)
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+os.environ.setdefault("SOORMA_AUTH_JWT_SECRET", "dev-identity-signing-key")
+
+
+def build_auth_headers(
+    platform_tenant_id: str = "spt_test-tenant",
+    service_tenant_id: str = "st_test-tenant",
+    service_user_id: str = "su_test-user",
+    principal_id: str = "tracker-test-user",
+    include_service_tenant_header: bool = True,
+    include_user_header: bool = True,
+) -> dict[str, str]:
+    """Build JWT bearer headers plus compatibility alias headers for tracker tests."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "sub": principal_id,
+            "platform_tenant_id": platform_tenant_id,
+            "service_tenant_id": service_tenant_id,
+            "service_user_id": service_user_id,
+            "principal_id": principal_id,
+            "principal_type": "service",
+            "roles": ["service"],
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        },
+        "dev-identity-signing-key",
+        algorithm="HS256",
+    )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Tenant-ID": platform_tenant_id,
+    }
+    if include_service_tenant_header:
+        headers["X-Service-Tenant-ID"] = service_tenant_id
+    if include_user_header:
+        headers["X-User-ID"] = service_user_id
+    return headers
 
 
 @pytest.fixture(scope="function")

--- a/services/tracker/tests/test_query_api.py
+++ b/services/tracker/tests/test_query_api.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracker_service.main import app
 from tracker_service.models.db import PlanProgress, ActionProgress, ActionStatus, PlanStatus
+from .conftest import build_auth_headers
 
 
 PLATFORM_TENANT = "spt_test-tenant"
@@ -51,11 +52,7 @@ class TestGetPlanProgress:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 f"/v1/tracker/plans/{plan_id}",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-Service-Tenant-ID": service_tenant_id,
-                    "X-User-ID": service_user_id,
-                }
+                headers=build_auth_headers(PLATFORM_TENANT, service_tenant_id, service_user_id),
             )
 
         # Assert: Returns 200 with PlanProgress DTO
@@ -79,11 +76,7 @@ class TestGetPlanProgress:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 "/v1/tracker/plans/nonexistent-plan",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-Service-Tenant-ID": SERVICE_TENANT,
-                    "X-User-ID": SERVICE_USER,
-                }
+                headers=build_auth_headers(PLATFORM_TENANT, SERVICE_TENANT, SERVICE_USER),
             )
 
         # Assert: Returns 404
@@ -115,11 +108,7 @@ class TestGetPlanProgress:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 f"/v1/tracker/plans/{plan_id}",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-Service-Tenant-ID": "st_other-tenant",
-                    "X-User-ID": SERVICE_USER,
-                }
+                headers=build_auth_headers(PLATFORM_TENANT, "st_other-tenant", SERVICE_USER),
             )
 
         # Assert: Returns 404 (plan exists but tenant filter blocks it)
@@ -133,10 +122,12 @@ class TestGetPlanProgress:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 "/v1/tracker/plans/plan-123",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-User-ID": SERVICE_USER,
-                },
+                headers=build_auth_headers(
+                    PLATFORM_TENANT,
+                    SERVICE_TENANT,
+                    SERVICE_USER,
+                    include_service_tenant_header=False,
+                ),
             )
 
         assert response.status_code == 422, f"Expected 422, got {response.status_code}: {response.text}"
@@ -203,11 +194,7 @@ class TestGetPlanActions:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 f"/v1/tracker/plans/{plan_id}/actions",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-Service-Tenant-ID": service_tenant_id,
-                    "X-User-ID": service_user_id,
-                }
+                headers=build_auth_headers(PLATFORM_TENANT, service_tenant_id, service_user_id),
             )
 
         # Assert: Returns 200 with List[TaskExecution]
@@ -251,11 +238,7 @@ class TestGetPlanActions:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 f"/v1/tracker/plans/{plan_id}/actions",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-Service-Tenant-ID": service_tenant_id,
-                    "X-User-ID": service_user_id,
-                }
+                headers=build_auth_headers(PLATFORM_TENANT, service_tenant_id, service_user_id),
             )
 
         # Assert: Returns 200 with empty list
@@ -304,11 +287,7 @@ class TestGetPlanActions:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 f"/v1/tracker/plans/{plan_id}/actions",
-                headers={
-                    "X-Tenant-ID": PLATFORM_TENANT,
-                    "X-Service-Tenant-ID": "st_other-tenant",
-                    "X-User-ID": SERVICE_USER,
-                }
+                headers=build_auth_headers(PLATFORM_TENANT, "st_other-tenant", SERVICE_USER),
             )
 
         # Assert: Returns empty list (actions exist but tenant filter blocks)


### PR DESCRIPTION
implemented cutover to use JWT for all soorma-core infrastructure services.

only identity service APIs use x-tenant-id and api key headers for admin operations (onboarding, token request, principal management etc.)

updated SDK implementation to use JWT provided with all low level clients, context wrappers and agent initialization.

migrated all examples to use new JWT authentication, along with adding a shared auth provider and boot strap method implementation.

closes #89 